### PR TITLE
feat: add PHP auth backend with JWT

### DIFF
--- a/api/login.php
+++ b/api/login.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__.'/../db.php';
+require_once __DIR__.'/../jwt.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$email = $input['email'] ?? '';
+$password = $input['password'] ?? '';
+
+if (!$email || !$password) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Email and password required']);
+    exit;
+}
+
+$db = get_db_connection();
+$stmt = $db->prepare('SELECT id, password FROM users WHERE email = :email');
+$stmt->execute([':email' => $email]);
+$user = $stmt->fetch();
+
+if (!$user || !password_verify($password, $user['password'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Invalid credentials']);
+    exit;
+}
+
+$token = generate_jwt(['sub' => $user['id'], 'email' => $email], JWT_SECRET);
+setcookie('token', $token, [
+    'httponly' => true,
+    'samesite' => 'Lax',
+    'path' => '/',
+]);
+
+echo json_encode(['token' => $token]);

--- a/api/logout.php
+++ b/api/logout.php
@@ -1,0 +1,9 @@
+<?php
+header('Content-Type: application/json');
+
+setcookie('token', '', [
+    'expires' => time() - 3600,
+    'path' => '/',
+]);
+
+echo json_encode(['success' => true]);

--- a/api/register.php
+++ b/api/register.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__.'/../db.php';
+require_once __DIR__.'/../jwt.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$email = $input['email'] ?? '';
+$password = $input['password'] ?? '';
+
+if (!$email || !$password) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Email and password required']);
+    exit;
+}
+
+$db = get_db_connection();
+$stmt = $db->prepare('SELECT id FROM users WHERE email = :email');
+$stmt->execute([':email' => $email]);
+
+if ($stmt->fetch()) {
+    http_response_code(409);
+    echo json_encode(['error' => 'Email already registered']);
+    exit;
+}
+
+$hash = password_hash($password, PASSWORD_DEFAULT);
+$stmt = $db->prepare('INSERT INTO users (email, password) VALUES (:email, :password)');
+$stmt->execute([':email' => $email, ':password' => $hash]);
+$userId = $db->lastInsertId();
+
+$token = generate_jwt(['sub' => $userId, 'email' => $email], JWT_SECRET);
+setcookie('token', $token, [
+    'httponly' => true,
+    'samesite' => 'Lax',
+    'path' => '/',
+]);
+
+echo json_encode(['token' => $token]);

--- a/config.php
+++ b/config.php
@@ -1,0 +1,12 @@
+<?php
+$env = [];
+$envFile = __DIR__.'/.env';
+if (file_exists($envFile)) {
+    $env = parse_ini_file($envFile, false, INI_SCANNER_TYPED);
+}
+
+define('DB_HOST', $env['DB_HOST'] ?? getenv('DB_HOST') ?? 'localhost');
+define('DB_NAME', $env['DB_NAME'] ?? getenv('DB_NAME') ?? 'app');
+define('DB_USER', $env['DB_USER'] ?? getenv('DB_USER') ?? 'root');
+define('DB_PASS', $env['DB_PASS'] ?? getenv('DB_PASS') ?? '');
+define('JWT_SECRET', $env['JWT_SECRET'] ?? getenv('JWT_SECRET') ?? 'change_me');

--- a/db.php
+++ b/db.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__.'/config.php';
+
+function get_db_connection(): PDO {
+    $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ];
+    return new PDO($dsn, DB_USER, DB_PASS, $options);
+}

--- a/env.example
+++ b/env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_NAME=app
+DB_USER=root
+DB_PASS=password
+JWT_SECRET=your_jwt_secret

--- a/jwt.php
+++ b/jwt.php
@@ -1,0 +1,17 @@
+<?php
+function base64url_encode(string $data): string {
+    return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+}
+
+function generate_jwt(array $payload, string $secret, int $exp = 3600): string {
+    $header = ['typ' => 'JWT', 'alg' => 'HS256'];
+    $payload['exp'] = time() + $exp;
+    $segments = [
+        base64url_encode(json_encode($header)),
+        base64url_encode(json_encode($payload)),
+    ];
+    $signing_input = implode('.', $segments);
+    $signature = base64url_encode(hash_hmac('sha256', $signing_input, $secret, true));
+    $segments[] = $signature;
+    return implode('.', $segments);
+}


### PR DESCRIPTION
## Summary
- add environment example for PHP config
- implement simple config and DB connection helpers
- add JWT helper and auth endpoints for login, register, and logout

## Testing
- `php -l config.php`
- `php -l db.php`
- `php -l jwt.php`
- `php -l api/register.php`
- `php -l api/login.php`
- `php -l api/logout.php`
- `phpcs` *(fails: command not found)*
- `npm test`
- `npm run lint`

## Checklist
- [ ] First-flight bundle still ≤ 14 KB (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [ ] PHP renders complete content without JS; htmx only enhances UX.
- [ ] New routes are code-split and lazy-loaded.
- [ ] SW registers after first paint; no large precache list added.
- [ ] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [ ] No regressions in a11y basics; titles/metas correct.
- [ ] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.

------
https://chatgpt.com/codex/tasks/task_e_68a7716f4a18832782bce8f76d1df154