### PR TITLE
feat: add Windows install docs and database setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ A template project for basic pwa/spa.
 
 ### Install PHP
 
+**Windows (winget):**
+
+```powershell
+winget install -e --id PHP.PHP
+```
+
 **macOS (Homebrew):**
 
 ```bash
@@ -28,6 +34,23 @@ sudo apt install php php-mysql
 Verify with `php -v`.
 
 ### Install SQL server
+
+**Windows (winget):**
+
+```powershell
+winget install -e --id Oracle.MySQL
+```
+
+After installation, secure the root account and create a regular user:
+
+```sql
+mysql -u root
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'new_password';
+CREATE USER 'user'@'localhost' IDENTIFIED BY 'user_password';
+GRANT ALL PRIVILEGES ON app.* TO 'user'@'localhost';
+FLUSH PRIVILEGES;
+EXIT;
+```
 
 **macOS:**
 
@@ -47,20 +70,20 @@ Verify with `mysql --version`.
 
 ### Configure database
 
-```sql
-mysql -u root -p
-CREATE DATABASE app;
-CREATE USER 'appuser'@'localhost' IDENTIFIED BY 'password';
-GRANT ALL PRIVILEGES ON app.* TO 'appuser'@'localhost';
-FLUSH PRIVILEGES;
-```
-
 Copy the example environment file and update it with your credentials:
 
 ```bash
 cp env.example .env
-# edit .env to match the database details above
+# Use the root credentials above for the initial setup
 ```
+
+Run the provided installation script to create the database and `users` table:
+
+```bash
+php install.php
+```
+
+Afterwards, update `.env` to use the `user` account you created.
 
 ### Install dependencies
 

--- a/install.php
+++ b/install.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+try {
+    $dsn = 'mysql:host=' . DB_HOST . ';charset=utf8mb4';
+    $options = [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ];
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+
+    $pdo->exec('CREATE DATABASE IF NOT EXISTS `' . DB_NAME . '` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+    $pdo->exec('USE `' . DB_NAME . '`');
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS users (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        email VARCHAR(255) NOT NULL UNIQUE,
+        password VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+    echo "Database setup complete\n";
+} catch (PDOException $e) {
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- document Windows setup for PHP and MySQL, including securing root and creating a `user`
- add install script to create the database and `users` table

## Testing
- `npm test`
- `npm run lint`
- `php -l install.php`

## PR Checklist
- [x] First-flight bundle still ≤ 14 KB (no change)
- [x] No new runtime dep, or size/security justification provided
- [x] PHP renders complete content without JS; htmx only enhances UX
- [x] New routes are code-split and lazy-loaded (n/a)
- [x] SW registers after first paint; no large precache list added
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth
- [x] No regressions in a11y basics; titles/metas correct
- [x] All assets hashed; caching headers appropriate
- [x] Budgets (LCP/CLS/INP) pass in CI


------
https://chatgpt.com/codex/tasks/task_e_68a77adf2628832788dfc56be538d80e