### PR TITLE
fix: add index.html and configure Vite entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PWA Template</title>
+  </head>
+  <body data-route="home">
+    <h1>PWA Template</h1>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vite";
+import { resolve } from "path";
 
 export default defineConfig({
     build: {
         outDir: "public/assets",
         emptyOutDir: true,
         rollupOptions: {
+            input: resolve(__dirname, "src/main.ts"),
             output: {
                 entryFileNames: "[name]-[hash].js",
                 chunkFileNames: "[name]-[hash].js",


### PR DESCRIPTION
## Summary
- add entry HTML page for local development to avoid 404 and bootstrap routes
- configure Vite build to use `src/main.ts` as entry so production builds no longer require `index.html`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

## PR Checklist
- [ ] First-flight bundle still ≤ 14 KB (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [ ] PHP renders complete content without JS; htmx only enhances UX.
- [ ] New routes are code-split and lazy-loaded.
- [ ] SW registers after first paint; no large precache list added.
- [ ] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [ ] No regressions in a11y basics; titles/metas correct.
- [ ] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.


------
https://chatgpt.com/codex/tasks/task_e_68a790a29b4483278606f4c827c62103