### PR TITLE
feat: add user listing API endpoint

### DIFF
--- a/api/users.php
+++ b/api/users.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__.'/../db.php';
+require_once __DIR__.'/../jwt.php';
+
+header('Content-Type: application/json');
+
+$token = $_COOKIE['token'] ?? '';
+$payload = verify_jwt($token, JWT_SECRET);
+if (!$payload) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$db = get_db_connection();
+$stmt = $db->prepare('SELECT id, email, created_at FROM users');
+$stmt->execute();
+$users = $stmt->fetchAll();
+
+echo json_encode(['users' => $users]);
+

--- a/jwt.php
+++ b/jwt.php
@@ -3,6 +3,14 @@ function base64url_encode(string $data): string {
     return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
 }
 
+function base64url_decode(string $data): string {
+    $remainder = strlen($data) % 4;
+    if ($remainder) {
+        $data .= str_repeat('=', 4 - $remainder);
+    }
+    return base64_decode(strtr($data, '-_', '+/'));
+}
+
 function generate_jwt(array $payload, string $secret, int $exp = 3600): string {
     $header = ['typ' => 'JWT', 'alg' => 'HS256'];
     $payload['exp'] = time() + $exp;
@@ -14,4 +22,21 @@ function generate_jwt(array $payload, string $secret, int $exp = 3600): string {
     $signature = base64url_encode(hash_hmac('sha256', $signing_input, $secret, true));
     $segments[] = $signature;
     return implode('.', $segments);
+}
+
+function verify_jwt(string $jwt, string $secret): array|false {
+    $parts = explode('.', $jwt);
+    if (count($parts) !== 3) {
+        return false;
+    }
+    [$headb64, $bodyb64, $sigb64] = $parts;
+    $signature = base64url_encode(hash_hmac('sha256', "$headb64.$bodyb64", $secret, true));
+    if (!hash_equals($signature, $sigb64)) {
+        return false;
+    }
+    $payload = json_decode(base64url_decode($bodyb64), true);
+    if (!is_array($payload) || ($payload['exp'] ?? 0) < time()) {
+        return false;
+    }
+    return $payload;
 }


### PR DESCRIPTION
## Summary
- expand JWT helper with decode and verify functions
- add authenticated `api/users.php` endpoint to list registered users

## Testing
- `php -l jwt.php`
- `php -l api/users.php`
- `npm test`
- `npm run lint`

## Checklist
- [x] First-flight bundle still ≤ **14 KB** (no front-end changes)
- [x] No new runtime dep, or size/security justification provided
- [x] PHP renders complete content without JS; htmx only enhances UX
- [x] New routes are code-split and lazy-loaded (N/A - backend API)
- [x] SW registers after first paint; no large precache list added
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth
- [x] No regressions in a11y basics; titles/metas correct (N/A)
- [x] All assets hashed; caching headers appropriate (N/A)
- [x] Budgets (LCP/CLS/INP) pass in CI (N/A)


------
https://chatgpt.com/codex/tasks/task_e_68a838b124f483279cc310c939be31b8