### PR TITLE
fix: validate auth responses

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ document.getElementById('register-btn')?.addEventListener('click', () => {
 
 document.getElementById('users-btn')?.addEventListener('click', () => {
     navigate('users');
+});
 
 const usernameEl = document.getElementById('username');
 const loginBtn = document.getElementById('login-btn') as HTMLButtonElement | null;

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -23,27 +23,33 @@ export default function init() {
         form?.addEventListener('submit', async (e) => {
             e.preventDefault();
             const formData = new FormData(form);
-            const response = await fetch('/api/login.php', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify({
-                    email: formData.get('email'),
-                    password: formData.get('password'),
-                }),
-            });
-              if (message) {
-                  if (response.ok) {
-                      message.textContent = 'Login successful';
-                      const email = formData.get('email') as string;
-                      document.dispatchEvent(
-                          new CustomEvent('auth-changed', { detail: email })
-                      );
-                  } else {
-                      const data = await response.json().catch(() => ({}));
-                      message.textContent = data.error || 'Login failed';
-                  }
-              }
+            try {
+                const response = await fetch('/api/login.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({
+                        email: formData.get('email'),
+                        password: formData.get('password'),
+                    }),
+                });
+                const data = await response.json().catch(() => ({}));
+                if (message) {
+                    if (response.ok && data.token) {
+                        message.textContent = 'Login successful';
+                        const email = formData.get('email') as string;
+                        document.dispatchEvent(
+                            new CustomEvent('auth-changed', { detail: email })
+                        );
+                    } else {
+                        message.textContent = data.error || 'Login failed';
+                    }
+                }
+            } catch {
+                if (message) {
+                    message.textContent = 'Login failed';
+                }
+            }
         });
     }
 }

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -23,28 +23,34 @@ export default function init() {
         form?.addEventListener('submit', async (e) => {
             e.preventDefault();
             const formData = new FormData(form);
-            const response = await fetch('/api/register.php', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify({
-                    email: formData.get('email'),
-                    password: formData.get('password'),
-                }),
-            });
-              if (message) {
-                  if (response.ok) {
-                      message.textContent = 'Registration successful';
-                      const email = formData.get('email') as string;
-                      document.dispatchEvent(
-                          new CustomEvent('auth-changed', { detail: email })
-                      );
-                  } else {
-                      const data = await response.json().catch(() => ({}));
-                      message.textContent =
-                          data.error || 'Registration failed';
-                  }
-              }
+            try {
+                const response = await fetch('/api/register.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({
+                        email: formData.get('email'),
+                        password: formData.get('password'),
+                    }),
+                });
+                const data = await response.json().catch(() => ({}));
+                if (message) {
+                    if (response.ok && data.token) {
+                        message.textContent = 'Registration successful';
+                        const email = formData.get('email') as string;
+                        document.dispatchEvent(
+                            new CustomEvent('auth-changed', { detail: email })
+                        );
+                    } else {
+                        message.textContent =
+                            data.error || 'Registration failed';
+                    }
+                }
+            } catch {
+                if (message) {
+                    message.textContent = 'Registration failed';
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- validate login/register responses and require JWT token before treating auth as successful
- handle network and server errors when fetching auth endpoints
- close missing bracket in main.ts causing lint failure

## Testing
- `npm run lint`
- `npm test`

## PR Checklist
- [ ] First-flight bundle still ≤ **14 KB** (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [x] PHP renders complete content without JS; htmx only enhances UX.
- [x] New routes are code-split and lazy-loaded.
- [x] SW registers after first paint; no large precache list added.
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [x] No regressions in a11y basics; titles/metas correct.
- [x] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.

------
https://chatgpt.com/codex/tasks/task_e_68a84d3501888327a18b378ccef79804