### PR TITLE
fix: connect dev frontend to PHP server via IPv4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "dev": "vite",
-        "start": "php -S localhost:8000",
+        "start": "php -S 127.0.0.1:8000",
         "build": "node scripts/build.js",
         "lint": "eslint \"src/**/*.{ts,tsx}\"",
         "test": "echo \"No tests\""

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     server: {
         proxy: {
             '/api': {
-                target: 'http://localhost:8000',
+                target: 'http://127.0.0.1:8000',
                 changeOrigin: true,
                 // optional: if PHP serves /api/register.php literally, no rewrite needed
                 // rewrite: (path) => path.replace(/^\/api/, '/api'),


### PR DESCRIPTION
## Summary
- ensure `npm start` binds PHP dev server to 127.0.0.1
- proxy Vite dev requests to 127.0.0.1:8000 to avoid pending API calls

## Testing
- `npm run lint`
- `npm test`

## PR Checklist
- [ ] First-flight bundle still ≤ **14 KB** (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [x] PHP renders complete content without JS; htmx only enhances UX.
- [x] New routes are code-split and lazy-loaded.
- [x] SW registers after first paint; no large precache list added.
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [x] No regressions in a11y basics; titles/metas correct.
- [x] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.


------
https://chatgpt.com/codex/tasks/task_e_68ac477a1c988327892be25b9de8b5aa