### PR TITLE
fix: add API base URL for auth endpoints

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,3 +5,4 @@ DB_A_PASS=password
 DB_USER=user
 DB_PASS=password
 JWT_SECRET=your_jwt_secret
+VITE_API_BASE_URL=http://127.0.0.1:8000/api

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { API_BASE } from './utils/api';
+
 const pathRoute = window.location.pathname.replace(/^\/+/, '');
 let route = pathRoute || document.body.dataset.route || 'home';
 
@@ -67,9 +69,15 @@ document.getElementById('users-btn')?.addEventListener('click', () => {
 });
 
 const usernameEl = document.getElementById('username');
-const loginBtn = document.getElementById('login-btn') as HTMLButtonElement | null;
-const registerBtn = document.getElementById('register-btn') as HTMLButtonElement | null;
-const logoutBtn = document.getElementById('logout-btn') as HTMLButtonElement | null;
+const loginBtn = document.getElementById(
+    'login-btn'
+) as HTMLButtonElement | null;
+const registerBtn = document.getElementById(
+    'register-btn'
+) as HTMLButtonElement | null;
+const logoutBtn = document.getElementById(
+    'logout-btn'
+) as HTMLButtonElement | null;
 const USER_KEY = 'userEmail';
 
 const updateAuthUI = (email: string | null) => {
@@ -103,7 +111,7 @@ document.addEventListener('auth-changed', (e) => {
 });
 
 logoutBtn?.addEventListener('click', async () => {
-    await fetch('/api/logout.php', {
+    await fetch(`${API_BASE}/logout.php`, {
         method: 'POST',
         credentials: 'include',
     });

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -1,3 +1,5 @@
+import { API_BASE } from '../utils/api';
+
 export default function init() {
     const content = document.getElementById('content');
     if (content) {
@@ -24,7 +26,7 @@ export default function init() {
             e.preventDefault();
             const formData = new FormData(form);
             try {
-                const response = await fetch('/api/login.php', {
+                const response = await fetch(`${API_BASE}/login.php`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     credentials: 'include',
@@ -53,4 +55,3 @@ export default function init() {
         });
     }
 }
-

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -1,3 +1,5 @@
+import { API_BASE } from '../utils/api';
+
 export default function init() {
     const content = document.getElementById('content');
     if (content) {
@@ -24,7 +26,7 @@ export default function init() {
             e.preventDefault();
             const formData = new FormData(form);
             try {
-                const response = await fetch('/api/register.php', {
+                const response = await fetch(`${API_BASE}/register.php`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     credentials: 'include',

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,3 @@
+export const API_BASE =
+    import.meta.env.VITE_API_BASE_URL ||
+    (import.meta.env.DEV ? 'http://127.0.0.1:8000/api' : '/api');


### PR DESCRIPTION
## Summary
- avoid pending register requests by using a configurable API base URL
- document VITE_API_BASE_URL in env example

## Testing
- `npx prettier -w src/utils/api.ts src/routes/register.ts src/routes/login.ts src/main.ts`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4d0b0c1c8327b4796f51f468b24c