### PR TITLE
fix: hide protected navigation buttons when logged out

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
                 <span id="username">Guest</span>
                 <button id="login-btn">Login</button>
                 <button id="register-btn">Register</button>
-                <button id="users-btn">Users</button>
-                <button id="logout-btn">Logout</button>
+                <button id="users-btn" style="display: none">Users</button>
+                <button id="logout-btn" style="display: none">Logout</button>
                 <button id="theme-toggle">Toggle Theme</button>
             </nav>
         </header>

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,21 +78,26 @@ const registerBtn = document.getElementById(
 const logoutBtn = document.getElementById(
     'logout-btn'
 ) as HTMLButtonElement | null;
+const usersBtn = document.getElementById(
+    'users-btn'
+) as HTMLButtonElement | null;
 const USER_KEY = 'userEmail';
 
 const updateAuthUI = (email: string | null) => {
     if (usernameEl) {
         usernameEl.textContent = email || 'Guest';
     }
-    if (loginBtn && registerBtn && logoutBtn) {
+    if (loginBtn && registerBtn && logoutBtn && usersBtn) {
         if (email) {
             loginBtn.style.display = 'none';
             registerBtn.style.display = 'none';
             logoutBtn.style.display = '';
+            usersBtn.style.display = '';
         } else {
             loginBtn.style.display = '';
             registerBtn.style.display = '';
             logoutBtn.style.display = 'none';
+            usersBtn.style.display = 'none';
         }
     }
 };


### PR DESCRIPTION
## Summary
- hide Users and Logout navigation buttons until user is authenticated

## Testing
- `npx prettier --write index.html src/main.ts`
- `npm run lint`
- `npm test`

## Checklist
- [ ] First-flight bundle still ≤ 14 KB (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [x] PHP renders complete content without JS; htmx only enhances UX.
- [x] New routes are code-split and lazy-loaded.
- [x] SW registers after first paint; no large precache list added.
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [x] No regressions in a11y basics; titles/metas correct.
- [x] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.


------
https://chatgpt.com/codex/tasks/task_e_68ac5a4c53c88327905b7a9249c6e3cf