### PR TITLE
fix: mount islands after swaps and add service worker

### DIFF
--- a/server/sw.js
+++ b/server/sw.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'runtime';
+
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+    if (event.request.method !== 'GET') return;
+    const url = new URL(event.request.url);
+    event.respondWith(
+        caches.open(CACHE_NAME).then(async (cache) => {
+            try {
+                const response = await fetch(event.request);
+                if (url.pathname.startsWith('/assets/')) {
+                    cache.put(event.request, response.clone());
+                }
+                return response;
+            } catch {
+                const cached = await cache.match(event.request);
+                if (cached) {
+                    return cached;
+                }
+                throw new Error('Network error');
+            }
+        })
+    );
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,7 +131,5 @@ document.body.addEventListener('htmx:afterSwap', (e) => {
         window.scrollTo(0, 0);
     }
 
-    if (target) {
-        mountIslands(target);
-    }
+    mountIslands();
 });


### PR DESCRIPTION
## Summary
- ensure islands mount after htmx swaps so users page loads
- add basic service worker script with asset caching

## Testing
- `npm test`
- `npm run lint`

## Checklist
- [ ] First-flight bundle still ≤ 14 KB (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [x] PHP renders complete content without JS; htmx only enhances UX.
- [x] New routes are code-split and lazy-loaded.
- [x] SW registers after first paint; no large precache list added.
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [x] No regressions in a11y basics; titles/metas correct.
- [x] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.


------
https://chatgpt.com/codex/tasks/task_e_68aecc4ab42c83279fb0eeea0aa0e1d8