### PR TITLE
feat: add home link and user details

### DIFF
--- a/server/api/users.php
+++ b/server/api/users.php
@@ -18,7 +18,7 @@ if (!$payload) {
 log_message("Users list requested by {$payload['email']}");
 
 $db = get_db_connection();
-$stmt = $db->prepare('SELECT id, email, created_at FROM users');
+$stmt = $db->prepare('SELECT id, username, email, created_at FROM users');
 $stmt->execute();
 $users = $stmt->fetchAll();
 

--- a/server/views/about.php
+++ b/server/views/about.php
@@ -1,4 +1,9 @@
 <div data-island="about">
     <h1>About</h1>
-    <p>About this app.</p>
+    <p>
+        This template demonstrates a progressive web app built with
+        server-rendered PHP views and htmx-enhanced navigation.
+        TypeScript islands are bundled with Vite and loaded on demand
+        to keep the first visit tiny and fast.
+    </p>
 </div>

--- a/server/views/layout.php
+++ b/server/views/layout.php
@@ -56,6 +56,7 @@ function vite_asset(string $entry) {
       <button id="menu-toggle" aria-label="Menu">☰</button>
         <nav id="nav-menu">
           <span id="username"><?= htmlspecialchars($username ?? 'Guest') ?></span>
+          <a id="home-link" href="/" hx-get="/" hx-push-url="true" hx-target="#content" hx-select="#content" hx-swap="outerHTML">Home</a>
           <a id="login-link" href="/login" hx-get="/login" hx-push-url="true" hx-target="#content" hx-select="#content" hx-swap="outerHTML">Login</a>
           <a id="register-link" href="/register" hx-get="/register" hx-push-url="true" hx-target="#content" hx-select="#content" hx-swap="outerHTML">Register</a>
           <a id="users-link" href="/users" hx-get="/users" hx-push-url="true" hx-target="#content" hx-select="#content" hx-swap="outerHTML" class="hidden">Users</a>

--- a/server/views/users.php
+++ b/server/views/users.php
@@ -1,5 +1,15 @@
 <div data-island="users">
     <h1>Users</h1>
-    <ul id="users-list"></ul>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Username</th>
+                <th>Email</th>
+                <th>Date Created</th>
+            </tr>
+        </thead>
+        <tbody id="users-list"></tbody>
+    </table>
     <div id="users-message"></div>
 </div>

--- a/src/islands/users.ts
+++ b/src/islands/users.ts
@@ -1,5 +1,5 @@
 export default async function init(el: HTMLElement) {
-    const list = el.querySelector('#users-list');
+    const list = el.querySelector<HTMLTableSectionElement>('#users-list');
     const message = el.querySelector('#users-message');
     try {
         const response = await fetch('/api/users.php', {
@@ -12,9 +12,13 @@ export default async function init(el: HTMLElement) {
                     .map(
                         (u: {
                             id: number;
+                            username: string;
                             email: string;
                             created_at: string;
-                        }) => `<li>${u.email}</li>`
+                        }) =>
+                            `<tr><td>${u.id}</td><td>${u.username}</td><td>${u.email}</td><td>${new Date(
+                                u.created_at
+                            ).toLocaleString()}</td></tr>`
                     )
                     .join('');
             } else if (message) {


### PR DESCRIPTION
## Summary
- add Home link for quick navigation
- expand About page with project details
- show user id, username, email and local creation date in a table

## Testing
- `npm test`
- `npm run lint`
- `php -l server/views/layout.php server/views/about.php server/views/users.php server/api/users.php`

## PR Checklist
- [ ] First-flight bundle still ≤ **14 KB** (attach Lighthouse/Bundle report).
- [x] No new runtime dep, or size/security justification provided.
- [x] PHP renders complete content without JS; htmx only enhances UX.
- [x] New routes are code-split and lazy-loaded.
- [x] SW registers after first paint; no large precache list added.
- [x] Micro-cache behavior unchanged or improved; bypass respected for auth.
- [x] No regressions in a11y basics; titles/metas correct.
- [x] All assets hashed; caching headers appropriate.
- [ ] Budgets (LCP/CLS/INP) pass in CI.


------
https://chatgpt.com/codex/tasks/task_e_68aeead29a9c832789068a027ba92aa9