### PR TITLE
fix: refresh parent select cache for definition modal

### DIFF
--- a/src/islands/definitions-tree.ts
+++ b/src/islands/definitions-tree.ts
@@ -537,9 +537,10 @@ export default function init(el: HTMLElement) {
         'definition-create-template'
     ) as HTMLTemplateElement | null;
 
-    const parentSelectCache = document.getElementById(
-        'definition-parent-select'
-    ) as HTMLElement | null;
+    const getParentSelectCache = () =>
+        document.getElementById('definition-parent-select') as
+            | HTMLElement
+            | null;
 
     const openCreateButton = document.getElementById(
         'definition-open-create'
@@ -616,6 +617,8 @@ export default function init(el: HTMLElement) {
     };
 
     const openCreateModal = (options: OpenCreateOptions = {}) => {
+        const parentSelectCache = getParentSelectCache();
+
         if (!modalRoot || !createTemplate || !parentSelectCache) return;
 
         const fragment = createTemplate.content.cloneNode(


### PR DESCRIPTION
## Summary
- re-query the cached parent select element before opening the create-definition modal so the latest options are cloned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12b34005c832792a9c342a0d1ba0b