### PR TITLE
Fix lint issues in definitions tree tests

### DIFF
--- a/src/islands/__tests__/definitions-tree.test.ts
+++ b/src/islands/__tests__/definitions-tree.test.ts
@@ -1,6 +1,11 @@
-import { isDescendantPath, setupDragAndDrop } from '../definitions-tree';
+import {
+    isDescendantPath,
+    setupDragAndDrop,
+} from '../definitions-tree';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 type AjaxFn = Parameters<typeof setupDragAndDrop>[2]['ajax'];
+type HtmxMock = { ajax: AjaxFn };
 
 describe('isDescendantPath', () => {
     it('detects descendants correctly', () => {
@@ -48,12 +53,14 @@ const createItem = (
 
 describe('setupDragAndDrop', () => {
     let ajaxMock: jest.Mock<ReturnType<AjaxFn>, Parameters<AjaxFn>>;
+    let htmxMock: HtmxMock;
 
     beforeEach(() => {
         document.body.innerHTML = '';
         ajaxMock = jest.fn<ReturnType<AjaxFn>, Parameters<AjaxFn>>(
             () => ({} as XMLHttpRequest)
         );
+        htmxMock = { ajax: ajaxMock };
     });
 
     const dispatchDragStart = (node: HTMLElement) => {
@@ -104,7 +111,7 @@ describe('setupDragAndDrop', () => {
 
         document.body.appendChild(root);
 
-        setupDragAndDrop(root, '', { ajax: ajaxMock } as any, root);
+        setupDragAndDrop(root, '', htmxMock, root);
 
         dispatchDragStart(child.node);
 
@@ -151,7 +158,7 @@ describe('setupDragAndDrop', () => {
 
         document.body.appendChild(root);
 
-        setupDragAndDrop(root, '', { ajax: ajaxMock } as any, root);
+        setupDragAndDrop(root, '', htmxMock, root);
 
         dispatchDragStart(second.node);
 


### PR DESCRIPTION
## Summary
- import the necessary Jest globals in the definitions tree unit tests so ESLint recognizes them
- replace the loose `any` cast with a typed HTMX mock to preserve type safety during drag-and-drop setup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d63f7cadc483278681f9fb53b4187d