### PR TITLE
Fix jest mock typing in definitions tree tests

### DIFF
--- a/src/islands/__tests__/definitions-tree.test.ts
+++ b/src/islands/__tests__/definitions-tree.test.ts
@@ -52,14 +52,13 @@ const createItem = (
 };
 
 describe('setupDragAndDrop', () => {
-    let ajaxMock: jest.Mock<ReturnType<AjaxFn>, Parameters<AjaxFn>>;
+    let ajaxMock: jest.MockedFunction<AjaxFn>;
     let htmxMock: HtmxMock;
 
     beforeEach(() => {
         document.body.innerHTML = '';
-        ajaxMock = jest.fn<ReturnType<AjaxFn>, Parameters<AjaxFn>>(
-            () => ({} as XMLHttpRequest)
-        );
+        ajaxMock = jest.fn<AjaxFn>();
+        ajaxMock.mockImplementation(() => ({} as XMLHttpRequest));
         htmxMock = { ajax: ajaxMock };
     });
 


### PR DESCRIPTION
## Summary
- update the definitions tree test to use jest.MockedFunction for the ajax mock
- initialize the ajax mock via mockImplementation so it matches Jest 30 typings

## Testing
- npm test -- --runTestsByPath src/islands/__tests__/definitions-tree.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d640da13d883279660effb7e540dbb