### PR TITLE
fix: ensure definitions create form posts via htmx

### DIFF
--- a/server/views/editor/partials/definitions.php
+++ b/server/views/editor/partials/definitions.php
@@ -34,6 +34,8 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
   <form
     class="definition-form definition-form--modal"
     hx-post="<?= htmlspecialchars($BASE) ?>/editor/definitions-create"
+    action="<?= htmlspecialchars($BASE) ?>/editor/definitions-create"
+    method="post"
     hx-target="#definitions-list"
     hx-select="#definitions-list"
     hx-swap="outerHTML"

--- a/src/islands/definitions-tree.ts
+++ b/src/islands/definitions-tree.ts
@@ -19,6 +19,7 @@ type HTMX = {
             select?: string;
         }
     ) => XMLHttpRequest;
+    process?: (elt: Element) => void;
 };
 
 type DragContext = {
@@ -555,6 +556,9 @@ export default function init(el: HTMLElement) {
         ) as HTMLElement;
 
         bodyContainer.appendChild(body);
+        if (htmx && typeof htmx.process === 'function') {
+            htmx.process(body);
+        }
         modalRoot.classList.remove('hidden');
         modalRoot.setAttribute('aria-hidden', 'false');
         modalRoot.querySelectorAll('[data-modal-close]').forEach((btn) =>


### PR DESCRIPTION
## Summary
- add a real POST fallback to the definitions create modal form so it still targets the create endpoint without htmx interception
- trigger htmx processing on the dynamically inserted modal form to enable AJAX submissions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d64e8feb1083279205f666faffc766