### PR TITLE
test: cover chained definition reparenting

### DIFF
--- a/server/tests/definitions_move_runner.php
+++ b/server/tests/definitions_move_runner.php
@@ -395,6 +395,26 @@ $scenarios = [
         ],
         'move' => ['id' => 31, 'parent' => 30, 'position' => 0],
     ],
+    'chained_reparenting_preserves_children' => [
+        'rows' => [
+            ['id' => 0, 'parent_id' => null, 'position' => 0, 'title' => 'Root A', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 1, 'parent_id' => 0, 'position' => 0, 'title' => 'Child A1', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 2, 'parent_id' => 0, 'position' => 1, 'title' => 'Child A2', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 3, 'parent_id' => null, 'position' => 1, 'title' => 'Root B', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 4, 'parent_id' => 3, 'position' => 0, 'title' => 'Child B1', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 5, 'parent_id' => 3, 'position' => 1, 'title' => 'Child B2', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 6, 'parent_id' => 3, 'position' => 2, 'title' => 'Child B3', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 7, 'parent_id' => null, 'position' => 2, 'title' => 'Root C', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 8, 'parent_id' => 7, 'position' => 0, 'title' => 'Child C1', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 9, 'parent_id' => null, 'position' => 3, 'title' => 'Root D', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+            ['id' => 10, 'parent_id' => null, 'position' => 4, 'title' => 'Root E', 'meta' => null, 'created_at' => null, 'updated_at' => null],
+        ],
+        'moves' => [
+            ['id' => 10, 'parent' => 9, 'position' => 0, 'label' => 'after_first'],
+            ['id' => 9, 'parent' => 7, 'position' => 0, 'label' => 'after_second'],
+            ['id' => 10, 'parent' => 3, 'position' => 2, 'label' => 'final'],
+        ],
+    ],
 ];
 
 if (!isset($scenarios[$scenario])) {
@@ -404,36 +424,68 @@ if (!isset($scenarios[$scenario])) {
 
 $scenarioData = $scenarios[$scenario];
 $pdo = new FakePDO($scenarioData['rows']);
-$move = $scenarioData['move'];
+
+/**
+ * @param array<int,array<string,mixed>> $rows
+ * @return array<int,array<string,mixed>>
+ */
+$sortRows = static function (array $rows): array {
+    $normalized = array_values($rows);
+    usort($normalized, static function (array $a, array $b): int {
+        $parentA = $a['parent_id'];
+        $parentB = $b['parent_id'];
+        if ($parentA === $parentB) {
+            if ($a['position'] === $b['position']) {
+                return $a['id'] <=> $b['id'];
+            }
+            return $a['position'] <=> $b['position'];
+        }
+        if ($parentA === null) {
+            return -1;
+        }
+        if ($parentB === null) {
+            return 1;
+        }
+        return $parentA <=> $parentB;
+    });
+    return $normalized;
+};
+
+$moves = [];
+if (isset($scenarioData['moves']) && is_array($scenarioData['moves'])) {
+    $moves = $scenarioData['moves'];
+} elseif (isset($scenarioData['move'])) {
+    $moves = [$scenarioData['move']];
+}
 
 $status = 'ok';
 $error = null;
+$snapshots = [];
 
 try {
-    definitions_move($pdo, (int) $move['id'], $move['parent'] === null ? null : (int) $move['parent'], (int) $move['position']);
+    foreach ($moves as $move) {
+        if (!is_array($move)) {
+            continue;
+        }
+        $id = isset($move['id']) ? (int) $move['id'] : 0;
+        $parent = null;
+        if (array_key_exists('parent', $move) && $move['parent'] !== null) {
+            $parent = (int) $move['parent'];
+        }
+        $position = isset($move['position']) ? (int) $move['position'] : 0;
+
+        definitions_move($pdo, $id, $parent, $position);
+
+        if (isset($move['label']) && $move['label'] !== '') {
+            $snapshots[(string) $move['label']] = $sortRows($pdo->rows);
+        }
+    }
 } catch (Throwable $e) {
     $status = 'error';
     $error = $e->getMessage();
 }
 
-$rows = array_values($pdo->rows);
-usort($rows, static function (array $a, array $b): int {
-    $parentA = $a['parent_id'];
-    $parentB = $b['parent_id'];
-    if ($parentA === $parentB) {
-        if ($a['position'] === $b['position']) {
-            return $a['id'] <=> $b['id'];
-        }
-        return $a['position'] <=> $b['position'];
-    }
-    if ($parentA === null) {
-        return -1;
-    }
-    if ($parentB === null) {
-        return 1;
-    }
-    return $parentA <=> $parentB;
-});
+$rows = $sortRows($pdo->rows);
 
 $output = [
     'status' => $status,
@@ -442,5 +494,9 @@ $output = [
     'operations' => $pdo->operations,
     'executions' => $pdo->executions,
 ];
+
+if ($snapshots !== []) {
+    $output['snapshots'] = $snapshots;
+}
 
 echo json_encode($output, JSON_PRETTY_PRINT);


### PR DESCRIPTION
## Summary
- add a multi-step chained reparenting scenario to the PHP definitions_move test harness
- record per-move snapshots so Jest tests can assert intermediate tree state
- extend the Jest suite with coverage for chained moves and final ordering checks

## Testing
- npx jest src/__tests__/definitions-move.server.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d65f0fcb488327b0dafbf48ef5a72d