### PR TITLE
Fix definitions tree drag requests to avoid stale swap target

### DIFF
--- a/src/islands/__tests__/definitions-tree.test.ts
+++ b/src/islands/__tests__/definitions-tree.test.ts
@@ -110,7 +110,7 @@ describe('setupDragAndDrop', () => {
 
         document.body.appendChild(root);
 
-        setupDragAndDrop(root, '', htmxMock, root);
+        setupDragAndDrop(root, '', htmxMock);
 
         dispatchDragStart(child.node);
 
@@ -136,8 +136,9 @@ describe('setupDragAndDrop', () => {
         expect(ajaxMock.mock.calls[0][0]).toBe('POST');
         expect(ajaxMock.mock.calls[0][1]).toBe('/editor/definitions-move');
         expect(ajaxMock.mock.calls[0][2]).toEqual({
+            source: '#definitions-list',
             values: { id: '2', parent_id: '3', position: '0' },
-            target: root,
+            target: '#definitions-list',
             swap: 'outerHTML',
             select: '#definitions-list',
         });
@@ -157,7 +158,7 @@ describe('setupDragAndDrop', () => {
 
         document.body.appendChild(root);
 
-        setupDragAndDrop(root, '', htmxMock, root);
+        setupDragAndDrop(root, '', htmxMock);
 
         dispatchDragStart(second.node);
 


### PR DESCRIPTION
## Summary
- update the definitions-tree island to send htmx requests using the shared selector so queued swaps always resolve the current list element
- simplify the drag-and-drop wiring to rely on the shared selector and adjust modal actions accordingly
- refresh the unit test expectations to cover the new htmx.ajax options

## Testing
- npm run lint
- npm run test *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d66baefc888327be49390104ee5df9