### PR TITLE
feat: scaffold editor components view

### DIFF
--- a/server/database/README.md
+++ b/server/database/README.md
@@ -8,6 +8,10 @@ This directory collects SQL migrations and helper snippets that can be executed 
 - `seeds/definitions.sample.sql` inserts the sample "Nástavba" hierarchy from the product brief.
 - `queries/select_definition_tree.sql` shows how to pull a full tree (ordered) for a given root.
 
+## Components domain
+
+- `migrations/20250920_create_components.sql` creates the `components` hierarchy linked to definitions. Each component references a definition, may nest under another component, and stores descriptive metadata plus a JSON dependency tree.
+
 **Suggested workflow**
 
 1. Run `php server/install.php` after updating database credentials in `.env`. This creates the base schema including the new definitions structures.

--- a/server/database/migrations/20250920_create_components.sql
+++ b/server/database/migrations/20250920_create_components.sql
@@ -1,0 +1,22 @@
+-- Migration: create hierarchical components storage linked to definitions
+-- Run against MySQL 8.0+
+
+CREATE TABLE IF NOT EXISTS components (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  definition_id BIGINT UNSIGNED NOT NULL,
+  parent_id BIGINT UNSIGNED DEFAULT NULL,
+  alternate_title VARCHAR(191) DEFAULT NULL,
+  description TEXT NOT NULL,
+  image VARCHAR(191) DEFAULT NULL,
+  dependency_tree JSON NOT NULL,
+  position INT UNSIGNED NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_components_definition FOREIGN KEY (definition_id) REFERENCES definitions(id) ON DELETE CASCADE,
+  CONSTRAINT fk_components_parent FOREIGN KEY (parent_id) REFERENCES components(id) ON DELETE SET NULL,
+  UNIQUE KEY uq_components_parent_position (parent_id, position),
+  KEY idx_components_definition (definition_id),
+  KEY idx_components_updated (updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+

--- a/server/database/queries/select_component_tree.sql
+++ b/server/database/queries/select_component_tree.sql
@@ -1,0 +1,56 @@
+-- Returns the full component hierarchy ordered by parent/position.
+-- Optional :root_id parameter limits to a subtree when provided.
+
+WITH RECURSIVE component_tree AS (
+  SELECT
+    c.id,
+    c.definition_id,
+    c.parent_id,
+    c.alternate_title,
+    c.description,
+    c.image,
+    c.dependency_tree,
+    c.position,
+    d.title AS definition_title,
+    c.id AS root_id,
+    CAST(c.id AS CHAR(1024)) AS path,
+    0 AS depth
+  FROM components c
+  INNER JOIN definitions d ON d.id = c.definition_id
+  WHERE (:root_id IS NULL AND c.parent_id IS NULL)
+     OR (:root_id IS NOT NULL AND c.id = :root_id)
+
+  UNION ALL
+
+  SELECT
+    child.id,
+    child.definition_id,
+    child.parent_id,
+    child.alternate_title,
+    child.description,
+    child.image,
+    child.dependency_tree,
+    child.position,
+    def.title AS definition_title,
+    component_tree.root_id,
+    CONCAT(component_tree.path, '/', child.id) AS path,
+    component_tree.depth + 1 AS depth
+  FROM components child
+  INNER JOIN component_tree ON component_tree.id = child.parent_id
+  INNER JOIN definitions def ON def.id = child.definition_id
+)
+SELECT
+  id,
+  definition_id,
+  parent_id,
+  alternate_title,
+  description,
+  image,
+  dependency_tree,
+  position,
+  definition_title,
+  root_id,
+  path,
+  depth
+FROM component_tree
+ORDER BY path;

--- a/server/install.php
+++ b/server/install.php
@@ -73,6 +73,28 @@ CREATE TABLE IF NOT EXISTS definition_components (
 SQL;
     $pdo->exec($definitionComponentsSql);
 
+    $componentsSql = <<<'SQL'
+CREATE TABLE IF NOT EXISTS components (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  definition_id BIGINT UNSIGNED NOT NULL,
+  parent_id BIGINT UNSIGNED DEFAULT NULL,
+  alternate_title VARCHAR(191) DEFAULT NULL,
+  description TEXT NOT NULL,
+  image VARCHAR(191) DEFAULT NULL,
+  dependency_tree JSON NOT NULL,
+  position INT UNSIGNED NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_components_definition FOREIGN KEY (definition_id) REFERENCES definitions(id) ON DELETE CASCADE,
+  CONSTRAINT fk_components_parent FOREIGN KEY (parent_id) REFERENCES components(id) ON DELETE SET NULL,
+  UNIQUE KEY uq_components_parent_position (parent_id, position),
+  KEY idx_components_definition (definition_id),
+  KEY idx_components_updated (updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+    $pdo->exec($componentsSql);
+
     $definitionTreeViewSql = <<<'SQL'
 CREATE OR REPLACE VIEW definition_tree AS
 WITH RECURSIVE tree AS (

--- a/server/lib/components.php
+++ b/server/lib/components.php
@@ -1,0 +1,92 @@
+<?php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/logger.php';
+
+function components_fetch_rows(?PDO $pdo = null): array {
+    $pdo = $pdo ?? get_db_connection();
+    $sql = 'SELECT c.id, c.definition_id, c.parent_id, c.alternate_title, c.description, c.image, c.dependency_tree, c.position, c.created_at, c.updated_at, d.title AS definition_title
+            FROM components c
+            INNER JOIN definitions d ON d.id = c.definition_id
+            ORDER BY (c.parent_id IS NULL) DESC, c.parent_id, c.position, c.id';
+    $stmt = $pdo->query($sql);
+    $rows = $stmt->fetchAll();
+    $normalised = [];
+    foreach ($rows as $row) {
+        $row['dependency_tree'] = components_normalise_dependency_tree($row['dependency_tree'] ?? null);
+        $row['effective_title'] = components_effective_title($row);
+        $normalised[] = $row;
+    }
+    log_message('Fetched ' . count($normalised) . ' components from database', 'DEBUG');
+    return $normalised;
+}
+
+function components_normalise_dependency_tree($raw): array {
+    if (is_array($raw)) {
+        return $raw;
+    }
+    if (is_string($raw) && $raw !== '') {
+        $decoded = json_decode($raw, true);
+        if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+            return $decoded;
+        }
+    }
+    return [];
+}
+
+function components_effective_title(array $row): string {
+    $alt = isset($row['alternate_title']) ? trim((string) $row['alternate_title']) : '';
+    if ($alt !== '') {
+        return $alt;
+    }
+    return isset($row['definition_title']) ? (string) $row['definition_title'] : '';
+}
+
+function components_group_by_parent(array $rows): array {
+    $grouped = [];
+    foreach ($rows as $row) {
+        $key = $row['parent_id'] === null ? 'root' : (string) $row['parent_id'];
+        $grouped[$key][] = $row;
+    }
+    return $grouped;
+}
+
+function components_build_branch(array $grouped, string $key): array {
+    if (!isset($grouped[$key])) {
+        return [];
+    }
+    $branch = [];
+    foreach ($grouped[$key] as $row) {
+        $childKey = (string) $row['id'];
+        $row['children'] = components_build_branch($grouped, $childKey);
+        $branch[] = $row;
+    }
+    return $branch;
+}
+
+function components_build_tree(array $rows): array {
+    $grouped = components_group_by_parent($rows);
+    $tree = components_build_branch($grouped, 'root');
+    log_message('Built component tree with ' . count($tree) . ' root nodes', 'DEBUG');
+    return $tree;
+}
+
+function components_flatten_tree(array $tree, int $depth = 0): array {
+    $flat = [];
+    foreach ($tree as $node) {
+        $children = $node['children'] ?? [];
+        $copy = $node;
+        $copy['depth'] = $depth;
+        unset($copy['children']);
+        $flat[] = $copy;
+        if (!empty($children)) {
+            $flat = array_merge($flat, components_flatten_tree($children, $depth + 1));
+        }
+    }
+    return $flat;
+}
+
+function components_fetch_tree(?PDO $pdo = null): array {
+    $rows = components_fetch_rows($pdo);
+    return components_build_tree($rows);
+}
+

--- a/server/views/editor/partials/components-tree.php
+++ b/server/views/editor/partials/components-tree.php
@@ -1,0 +1,59 @@
+<?php
+$tree = $componentsTree ?? [];
+$BASE = rtrim((defined('BASE_PATH') ? BASE_PATH : ''), '/');
+
+if (!function_exists('render_component_nodes')) {
+    function render_component_nodes(array $nodes): void {
+        if (empty($nodes)) {
+            return;
+        }
+        echo '<ul class="component-tree">';
+        foreach ($nodes as $node) {
+            $id = (int) $node['id'];
+            $definitionId = (int) $node['definition_id'];
+            $effectiveTitle = htmlspecialchars($node['effective_title'] ?? '', ENT_QUOTES, 'UTF-8');
+            $definitionTitle = htmlspecialchars($node['definition_title'] ?? '', ENT_QUOTES, 'UTF-8');
+            $alternateTitle = isset($node['alternate_title']) && $node['alternate_title'] !== null
+                ? htmlspecialchars($node['alternate_title'], ENT_QUOTES, 'UTF-8')
+                : '';
+            $description = htmlspecialchars($node['description'] ?? '', ENT_QUOTES, 'UTF-8');
+            $image = isset($node['image']) ? htmlspecialchars((string) $node['image'], ENT_QUOTES, 'UTF-8') : '';
+            $dependencyCount = isset($node['dependency_tree']) && is_array($node['dependency_tree'])
+                ? count($node['dependency_tree'])
+                : 0;
+            echo '<li class="component-item" data-id="' . $id . '">';
+            echo '<div class="component-node">';
+            echo '<div class="component-node__header">';
+            echo '<strong>' . $effectiveTitle . '</strong>';
+            if ($alternateTitle !== '') {
+                echo '<span class="component-node__subtitle">alias „' . $alternateTitle . '“</span>';
+            }
+            echo '</div>';
+            echo '<dl class="component-node__meta">';
+            echo '<div><dt>Definice</dt><dd>' . $definitionTitle . ' (#' . $definitionId . ')</dd></div>';
+            if ($description !== '') {
+                echo '<div><dt>Popis</dt><dd>' . $description . '</dd></div>';
+            }
+            if ($image !== '') {
+                echo '<div><dt>Obrázek</dt><dd>' . $image . '</dd></div>';
+            }
+            echo '<div><dt>Závislosti</dt><dd>' . $dependencyCount . '</dd></div>';
+            echo '</dl>';
+            echo '</div>';
+            $children = $node['children'] ?? [];
+            if (!empty($children)) {
+                render_component_nodes($children);
+            }
+            echo '</li>';
+        }
+        echo '</ul>';
+    }
+}
+?>
+<div id="components-list">
+  <?php if (empty($tree)): ?>
+    <p class="components-empty">Zatím nebyly vytvořeny žádné komponenty.</p>
+  <?php else: ?>
+    <?php render_component_nodes($tree); ?>
+  <?php endif; ?>
+</div>

--- a/server/views/editor/partials/components.php
+++ b/server/views/editor/partials/components.php
@@ -1,2 +1,43 @@
+<?php
+require_once __DIR__ . '/../../../lib/db.php';
+require_once __DIR__ . '/../../../lib/components.php';
+
+$BASE = rtrim((defined('BASE_PATH') ? BASE_PATH : ''), '/');
+$pdo = get_db_connection();
+$componentsTree = components_fetch_tree($pdo);
+$componentsFlat = components_flatten_tree($componentsTree);
+?>
+
 <h2>Komponenty</h2>
-<p>Zde bude správa komponent.</p>
+<p style="max-width:640px">Komponenty rozšiřují definice konfigurátoru o konkrétní stavební bloky. Každá komponenta vychází z vybrané definice, může mít vlastní hierarchii a ukládá popis, obrázek i závislosti na dalších volbách.</p>
+
+<div class="component-toolbar">
+  <a class="component-primary" href="#" aria-disabled="true">Přidat komponentu (připravujeme)</a>
+</div>
+
+<div class="component-summary">
+  <p><strong>Celkem komponent:</strong> <?= count($componentsFlat) ?></p>
+</div>
+
+<?php include __DIR__ . '/components-tree.php'; ?>
+
+<style>
+  .component-toolbar{margin:1rem 0;display:flex;justify-content:flex-start}
+  .component-primary{border:1px solid var(--primary);background:var(--primary);color:var(--primary-contrast);border-radius:.35rem;padding:.4rem .75rem;font-weight:600;cursor:not-allowed;opacity:.6;text-decoration:none}
+  .component-summary{font-size:.9rem;color:var(--fg-muted,#4b5563)}
+  .components-empty{font-style:italic;color:#6b7280}
+  .component-tree{list-style:none;padding-left:1rem;margin:1.5rem 0;display:flex;flex-direction:column;gap:.5rem}
+  .component-tree ul{list-style:none;padding-left:1.25rem;margin:.35rem 0 0 0;display:flex;flex-direction:column;gap:.5rem;border-left:1px dashed rgba(0,0,0,.2)}
+  [data-theme="dark"] .component-tree ul{border-color:rgba(255,255,255,.25)}
+  .component-item{position:relative}
+  .component-node{border:1px solid rgba(0,0,0,.15);border-radius:.4rem;padding:.6rem .75rem;background:rgba(0,0,0,.02);display:flex;flex-direction:column;gap:.5rem}
+  [data-theme="dark"] .component-node{border-color:rgba(255,255,255,.2);background:rgba(255,255,255,.05)}
+  .component-node__header{display:flex;flex-wrap:wrap;gap:.35rem;align-items:baseline}
+  .component-node__header strong{font-weight:600;font-size:1rem}
+  .component-node__subtitle{font-size:.85rem;color:#4b5563}
+  [data-theme="dark"] .component-node__subtitle{color:#cbd5e1}
+  .component-node__meta{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.5rem;margin:0}
+  .component-node__meta dt{font-weight:600;font-size:.75rem;color:#4b5563;margin-bottom:.2rem}
+  [data-theme="dark"] .component-node__meta dt{color:#cbd5e1}
+  .component-node__meta dd{margin:0;font-size:.85rem}
+</style>


### PR DESCRIPTION
## Summary
- add a components table migration and installer hook to store editor metadata alongside definitions
- expose SQL helper query and PHP utilities for fetching the component hierarchy
- render the editor components tab with a tree view scaffold that surfaces component metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6783af6308327bb785c4f03d6d7bc