### PR TITLE
feat: add component creation modal and endpoints

### DIFF
--- a/server/index.php
+++ b/server/index.php
@@ -48,6 +48,15 @@ if (isset($_SERVER['HTTP_HX_REQUEST']) && strpos($route, 'editor/definitions-') 
   exit;
 }
 
+if (isset($_SERVER['HTTP_HX_REQUEST']) && strpos($route, 'editor/components-') === 0) {
+  if (is_file($viewPath)) {
+    require $viewPath;
+  } else {
+    http_response_code(404);
+  }
+  exit;
+}
+
 if (is_file($viewPath)) {
   http_response_code(200);
   $view = $route;

--- a/server/views/editor/components-create.php
+++ b/server/views/editor/components-create.php
@@ -1,0 +1,124 @@
+<?php
+require_once __DIR__ . '/../../config/config.php';
+require_once __DIR__ . '/../../lib/auth.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/logger.php';
+require_once __DIR__ . '/../../lib/components.php';
+require_once __DIR__ . '/../../lib/definitions.php';
+require_once __DIR__ . '/components-response.php';
+
+log_message('Components create request received', 'INFO');
+
+if (!headers_sent()) {
+    header('Content-Type: text/html; charset=utf-8');
+    header('Vary: HX-Request, HX-Boosted, X-Requested-With, Cookie');
+}
+
+$user = app_get_current_user();
+$role = $user['role'] ?? 'guest';
+if (!in_array($role, ['admin', 'superadmin'], true)) {
+    http_response_code(403);
+    echo '<div id="components-list"></div>';
+    echo '<div id="component-form-errors" hx-swap-oob="true" class="form-feedback form-feedback--error">Nemáte oprávnění spravovat komponenty.</div>';
+    return;
+}
+
+$pdo = get_db_connection();
+
+$definitionParam = $_POST['definition_id'] ?? '';
+$parentParam = $_POST['parent_id'] ?? '';
+$alternateTitle = isset($_POST['alternate_title']) ? trim((string) $_POST['alternate_title']) : '';
+$description = isset($_POST['description']) ? trim((string) $_POST['description']) : '';
+$image = isset($_POST['image']) ? trim((string) $_POST['image']) : '';
+$positionParam = isset($_POST['position']) ? trim((string) $_POST['position']) : '';
+
+$errors = [];
+$definitionId = null;
+$parentId = null;
+$position = null;
+
+if ($definitionParam === '' || !preg_match('/^\d+$/', (string) $definitionParam)) {
+    $errors[] = 'Vyberte prosím platnou definici.';
+} else {
+    $definitionId = (int) $definitionParam;
+    if (!definitions_find($pdo, $definitionId)) {
+        $errors[] = 'Zvolená definice neexistuje.';
+    }
+}
+
+if ($alternateTitle !== '' && mb_strlen($alternateTitle, 'UTF-8') > 191) {
+    $errors[] = 'Alternativní název může mít maximálně 191 znaků.';
+}
+
+if ($description !== '' && mb_strlen($description, 'UTF-8') > 1000) {
+    $errors[] = 'Popis může mít maximálně 1000 znaků.';
+}
+
+if ($image !== '' && mb_strlen($image, 'UTF-8') > 255) {
+    $errors[] = 'Cesta k obrázku je příliš dlouhá (max 255 znaků).';
+}
+
+if ($parentParam !== '') {
+    if (!preg_match('/^\d+$/', (string) $parentParam)) {
+        $errors[] = 'Vybraný rodič není platný.';
+    } else {
+        $parentId = (int) $parentParam;
+        if ($parentId <= 0 || !components_parent_exists($pdo, $parentId)) {
+            $errors[] = 'Zvolená rodičovská komponenta neexistuje.';
+        }
+    }
+}
+
+if ($positionParam !== '') {
+    if (!preg_match('/^\d+$/', $positionParam)) {
+        $errors[] = 'Pozice musí být nezáporné číslo.';
+    } else {
+        $position = (int) $positionParam;
+    }
+}
+
+if (!empty($errors)) {
+    http_response_code(422);
+    components_render_fragments($pdo, [
+        'message' => implode(' ', $errors),
+        'message_type' => 'error',
+    ]);
+    return;
+}
+
+if ($definitionId === null) {
+    http_response_code(422);
+    components_render_fragments($pdo, [
+        'message' => 'Vyberte prosím definici.',
+        'message_type' => 'error',
+    ]);
+    return;
+}
+
+if ($position === null) {
+    $position = components_next_position($pdo, $parentId);
+}
+
+try {
+    components_create(
+        $pdo,
+        $definitionId,
+        $parentId,
+        $alternateTitle !== '' ? $alternateTitle : null,
+        $description !== '' ? $description : null,
+        $image !== '' ? $image : null,
+        $position
+    );
+    http_response_code(201);
+    components_render_fragments($pdo, [
+        'message' => 'Komponenta byla uložena.',
+        'message_type' => 'success',
+    ]);
+} catch (Throwable $e) {
+    log_message('Component creation failed: ' . $e->getMessage(), 'ERROR');
+    http_response_code(500);
+    components_render_fragments($pdo, [
+        'message' => 'Komponentu se nepodařilo uložit.',
+        'message_type' => 'error',
+    ]);
+}

--- a/server/views/editor/components-response.php
+++ b/server/views/editor/components-response.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../../lib/components.php';
+require_once __DIR__ . '/../../lib/definitions.php';
+
+function components_render_fragments(PDO $pdo, array $options = []): void {
+    $componentsTree = components_fetch_tree($pdo);
+    $componentsFlat = components_flatten_tree($componentsTree);
+    $definitionsTree = definitions_fetch_tree($pdo);
+    $definitionsFlat = definitions_flatten_tree($definitionsTree);
+    $BASE = rtrim((defined('BASE_PATH') ? BASE_PATH : ''), '/');
+    $message = $options['message'] ?? null;
+    $messageType = $options['message_type'] ?? 'success';
+
+    include __DIR__ . '/partials/components-tree.php';
+
+    ob_start();
+    include __DIR__ . '/partials/components-create-form.php';
+    $formMarkup = ob_get_clean();
+    echo '<template id="component-create-template" hx-swap-oob="true">' . $formMarkup . '</template>';
+
+    $totalCount = count($componentsFlat);
+    echo '<div id="component-summary" hx-swap-oob="true" class="component-summary"><p><strong>Celkem komponent:</strong> ' . $totalCount . '</p></div>';
+
+    $class = 'form-feedback';
+    if ($message) {
+        $class .= $messageType === 'error' ? ' form-feedback--error' : ' form-feedback--success';
+    } else {
+        $class .= ' hidden';
+    }
+    $safeMessage = $message ? htmlspecialchars($message, ENT_QUOTES, 'UTF-8') : '';
+    echo '<div id="component-form-errors" hx-swap-oob="true" class="' . $class . '" role="status" aria-live="polite">' . $safeMessage . '</div>';
+}

--- a/server/views/editor/partials/components-create-form.php
+++ b/server/views/editor/partials/components-create-form.php
@@ -1,0 +1,95 @@
+<?php
+$definitionOptions = $definitionsFlat ?? [];
+$componentOptions = $componentsFlat ?? [];
+?>
+<form
+  class="component-form component-form--modal"
+  hx-post="<?= htmlspecialchars($BASE) ?>/editor/components-create"
+  action="<?= htmlspecialchars($BASE) ?>/editor/components-create"
+  method="post"
+  hx-target="#components-list"
+  hx-select="#components-list"
+  hx-swap="outerHTML"
+>
+  <fieldset>
+    <legend>Přidat novou komponentu</legend>
+    <div class="component-field">
+      <label for="component-modal-definition">Definice</label>
+      <select id="component-modal-definition" name="definition_id" required>
+        <option value="" disabled selected>Vyberte definici</option>
+        <?php foreach ($definitionOptions as $definition): ?>
+          <?php
+            $depth = isset($definition['depth']) ? (int) $definition['depth'] : 0;
+            $indent = $depth > 0 ? str_repeat('— ', $depth) : '';
+            $title = htmlspecialchars($definition['title'] ?? '', ENT_QUOTES, 'UTF-8');
+            $id = (int) ($definition['id'] ?? 0);
+          ?>
+          <option value="<?= $id ?>"><?= $indent . $title ?> (ID <?= $id ?>)</option>
+        <?php endforeach; ?>
+      </select>
+      <p class="component-help">Povinné pole. Každá komponenta vychází z konkrétní definice.</p>
+    </div>
+    <div class="component-field">
+      <label for="component-modal-title">Alternativní název</label>
+      <input
+        type="text"
+        id="component-modal-title"
+        name="alternate_title"
+        maxlength="191"
+        placeholder="např. Vchodový modul"
+      >
+      <p class="component-help">Nepovinné. Pokud je vyplněno, zobrazí se místo názvu definice.</p>
+    </div>
+    <div class="component-field">
+      <label for="component-modal-parent">Rodič</label>
+      <select id="component-modal-parent" name="parent_id">
+        <option value="">Kořenová komponenta</option>
+        <?php foreach ($componentOptions as $component): ?>
+          <?php
+            $depth = isset($component['depth']) ? (int) $component['depth'] : 0;
+            $indent = $depth > 0 ? str_repeat('— ', $depth) : '';
+            $title = htmlspecialchars($component['effective_title'] ?? ($component['alternate_title'] ?? ''), ENT_QUOTES, 'UTF-8');
+            $id = (int) ($component['id'] ?? 0);
+          ?>
+          <option value="<?= $id ?>"><?= $indent . $title ?> (ID <?= $id ?>)</option>
+        <?php endforeach; ?>
+      </select>
+      <p class="component-help">Volitelné. Zvolte rodičovskou komponentu pro vytvoření hierarchie.</p>
+    </div>
+    <div class="component-field">
+      <label for="component-modal-position">Pozice</label>
+      <input
+        type="number"
+        id="component-modal-position"
+        name="position"
+        min="0"
+        step="1"
+        placeholder="automaticky"
+      >
+      <p class="component-help">Pořadí mezi sourozenci (0 = první). Prázdné pole přidá položku na konec.</p>
+    </div>
+    <div class="component-field">
+      <label for="component-modal-description">Popis</label>
+      <textarea
+        id="component-modal-description"
+        name="description"
+        rows="4"
+        placeholder="Krátký popis komponenty"
+      ></textarea>
+    </div>
+    <div class="component-field">
+      <label for="component-modal-image">Obrázek</label>
+      <input
+        type="text"
+        id="component-modal-image"
+        name="image"
+        maxlength="255"
+        placeholder="např. /assets/components/modul.jpg"
+      >
+    </div>
+  </fieldset>
+  <div class="components-modal-actions">
+    <button type="button" class="component-action" data-modal-close>Storno</button>
+    <button type="submit" class="component-primary">Uložit</button>
+  </div>
+</form>

--- a/server/views/editor/partials/components.php
+++ b/server/views/editor/partials/components.php
@@ -1,29 +1,45 @@
 <?php
 require_once __DIR__ . '/../../../lib/db.php';
 require_once __DIR__ . '/../../../lib/components.php';
+require_once __DIR__ . '/../../../lib/definitions.php';
 
 $BASE = rtrim((defined('BASE_PATH') ? BASE_PATH : ''), '/');
 $pdo = get_db_connection();
 $componentsTree = components_fetch_tree($pdo);
 $componentsFlat = components_flatten_tree($componentsTree);
+$definitionsTree = definitions_fetch_tree($pdo);
+$definitionsFlat = definitions_flatten_tree($definitionsTree);
 ?>
 
-<h2>Komponenty</h2>
-<p style="max-width:640px">Komponenty rozšiřují definice konfigurátoru o konkrétní stavební bloky. Každá komponenta vychází z vybrané definice, může mít vlastní hierarchii a ukládá popis, obrázek i závislosti na dalších volbách.</p>
+<div id="components-root" data-island="components" data-base="<?= htmlspecialchars($BASE) ?>">
+  <h2>Komponenty</h2>
+  <p style="max-width:640px">Komponenty rozšiřují definice konfigurátoru o konkrétní stavební bloky. Každá komponenta vychází z vybrané definice, může mít vlastní hierarchii a ukládá popis, obrázek i závislosti na dalších volbách.</p>
 
-<div class="component-toolbar">
-  <a class="component-primary" href="#" aria-disabled="true">Přidat komponentu (připravujeme)</a>
+  <div class="component-toolbar">
+    <button type="button" id="component-open-create" class="component-primary">Přidat komponentu</button>
+  </div>
+
+  <div id="component-form-errors" class="form-feedback hidden" role="status" aria-live="polite"></div>
+
+  <div id="component-summary" class="component-summary">
+    <p><strong>Celkem komponent:</strong> <?= count($componentsFlat) ?></p>
+  </div>
+
+  <template id="component-create-template">
+    <?php include __DIR__ . '/components-create-form.php'; ?>
+  </template>
+
+  <div id="components-modal" class="components-modal hidden" aria-hidden="true"></div>
+
+  <?php include __DIR__ . '/components-tree.php'; ?>
 </div>
-
-<div class="component-summary">
-  <p><strong>Celkem komponent:</strong> <?= count($componentsFlat) ?></p>
-</div>
-
-<?php include __DIR__ . '/components-tree.php'; ?>
 
 <style>
   .component-toolbar{margin:1rem 0;display:flex;justify-content:flex-start}
-  .component-primary{border:1px solid var(--primary);background:var(--primary);color:var(--primary-contrast);border-radius:.35rem;padding:.4rem .75rem;font-weight:600;cursor:not-allowed;opacity:.6;text-decoration:none}
+  .component-primary{border:1px solid var(--primary);background:var(--primary);color:var(--primary-contrast);border-radius:.35rem;padding:.4rem .75rem;font-weight:600;cursor:pointer;text-decoration:none}
+  .component-primary:hover,.component-primary:focus-visible{background:var(--primary-hover);border-color:var(--primary-hover)}
+  .component-action{border:1px solid var(--primary);background:transparent;color:var(--primary);border-radius:.25rem;padding:.3rem .6rem;font-size:.85rem;cursor:pointer}
+  .component-action:hover,.component-action:focus-visible{background:var(--primary);color:var(--primary-contrast)}
   .component-summary{font-size:.9rem;color:var(--fg-muted,#4b5563)}
   .components-empty{font-style:italic;color:#6b7280}
   .component-tree{list-style:none;padding-left:1rem;margin:1.5rem 0;display:flex;flex-direction:column;gap:.5rem}
@@ -40,4 +56,25 @@ $componentsFlat = components_flatten_tree($componentsTree);
   .component-node__meta dt{font-weight:600;font-size:.75rem;color:#4b5563;margin-bottom:.2rem}
   [data-theme="dark"] .component-node__meta dt{color:#cbd5e1}
   .component-node__meta dd{margin:0;font-size:.85rem}
+  .components-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.4);padding:1rem;z-index:2000}
+  .components-modal.hidden{display:none}
+  .components-modal__overlay{position:absolute;inset:0;background:transparent;cursor:pointer}
+  .components-modal__panel{position:relative;background:var(--bg);color:var(--fg);border-radius:.5rem;box-shadow:0 12px 32px rgba(0,0,0,.22);max-width:480px;width:100%;padding:1rem;display:flex;flex-direction:column;gap:1rem;z-index:1}
+  .components-modal__panel header{display:flex;justify-content:space-between;align-items:center;gap:.5rem}
+  .components-modal__panel header h3{margin:0;font-size:1.1rem}
+  .components-modal__panel header button{border:none;background:transparent;color:inherit;font-size:1.2rem;cursor:pointer}
+  .components-modal__body{display:flex;flex-direction:column;gap:1rem}
+  .component-form--modal{display:flex;flex-direction:column;gap:.75rem}
+  .component-form--modal fieldset{border:0;padding:0;margin:0;display:flex;flex-direction:column;gap:.75rem}
+  .component-field{display:flex;flex-direction:column;gap:.35rem}
+  .component-field label{font-weight:600;font-size:.9rem}
+  .component-form--modal input,.component-form--modal select,.component-form--modal textarea{border:1px solid var(--fg);border-radius:.35rem;padding:.4rem .5rem;font:inherit;background:transparent;color:inherit}
+  .component-form--modal input:focus,.component-form--modal select:focus,.component-form--modal textarea:focus{outline:2px solid var(--primary);outline-offset:1px}
+  .components-modal-actions{display:flex;justify-content:flex-end;gap:.5rem}
+  .component-help{font-size:.75rem;color:#6b7280;margin:0}
+  [data-theme="dark"] .component-help{color:#cbd5e1}
+  .form-feedback{font-size:.85rem;border-radius:.35rem;padding:.5rem .6rem;margin:.5rem 0 0}
+  .form-feedback.hidden{display:none}
+  .form-feedback.form-feedback--error{background:rgba(220,38,38,.12);border:1px solid #dc2626;color:#dc2626}
+  .form-feedback.form-feedback--success{background:rgba(22,163,74,.12);border:1px solid #16a34a;color:#166534}
 </style>

--- a/src/islands/components.ts
+++ b/src/islands/components.ts
@@ -1,0 +1,119 @@
+const escapeHtml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+type HTMX = {
+    process?: (elt: Element) => void;
+};
+
+type AfterRequestDetail = {
+    xhr?: XMLHttpRequest;
+};
+
+const getHtmx = (): HTMX | null => {
+    const win = window as unknown as { htmx?: HTMX };
+    return win.htmx ?? null;
+};
+
+const focusFirstField = (container: HTMLElement) => {
+    const field = container.querySelector<HTMLElement>(
+        'input, select, textarea'
+    );
+    field?.focus();
+};
+
+export default function init(root: HTMLElement) {
+    const modalRoot = document.getElementById(
+        'components-modal'
+    ) as HTMLElement | null;
+    const createTemplate = document.getElementById(
+        'component-create-template'
+    ) as HTMLTemplateElement | null;
+    const openButton = root.querySelector<HTMLButtonElement>(
+        '#component-open-create'
+    );
+    const htmx = getHtmx();
+
+    if (!modalRoot || !createTemplate) {
+        return;
+    }
+
+    let escHandler: ((event: KeyboardEvent) => void) | null = null;
+
+    const closeModal = () => {
+        modalRoot.classList.add('hidden');
+        modalRoot.setAttribute('aria-hidden', 'true');
+        modalRoot.innerHTML = '';
+        if (escHandler) {
+            document.removeEventListener('keydown', escHandler);
+            escHandler = null;
+        }
+    };
+
+    const openModal = (title: string, body: HTMLElement) => {
+        modalRoot.innerHTML = `
+            <div class="components-modal__overlay" data-modal-close></div>
+            <div class="components-modal__panel" role="dialog" aria-modal="true">
+              <header>
+                <h3>${escapeHtml(title)}</h3>
+                <button type="button" class="component-action" data-modal-close aria-label="Zavřít">×</button>
+              </header>
+              <div class="components-modal__body"></div>
+            </div>
+        `;
+        const bodyContainer = modalRoot.querySelector(
+            '.components-modal__body'
+        ) as HTMLElement | null;
+        if (!bodyContainer) {
+            return;
+        }
+        bodyContainer.appendChild(body);
+        if (htmx && typeof htmx.process === 'function') {
+            htmx.process(body);
+        }
+        modalRoot.classList.remove('hidden');
+        modalRoot.setAttribute('aria-hidden', 'false');
+        modalRoot.querySelectorAll('[data-modal-close]').forEach((btn) => {
+            btn.addEventListener('click', (event) => {
+                event.preventDefault();
+                closeModal();
+            });
+        });
+
+        escHandler = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeModal();
+            }
+        };
+        document.addEventListener('keydown', escHandler);
+    };
+
+    const openCreateModal = () => {
+        const fragment = createTemplate.content.cloneNode(
+            true
+        ) as DocumentFragment;
+        const form = fragment.querySelector('form');
+        if (!form) {
+            return;
+        }
+        openModal('Přidat komponentu', form as HTMLElement);
+        focusFirstField(form as HTMLElement);
+        form.addEventListener('htmx:afterRequest', (event) => {
+            const detail = (event as CustomEvent<AfterRequestDetail>).detail;
+            const status = detail?.xhr?.status ?? 0;
+            if (status && status < 400) {
+                closeModal();
+            }
+        });
+    };
+
+    openButton?.addEventListener('click', (event) => {
+        event.preventDefault();
+        openCreateModal();
+    });
+}


### PR DESCRIPTION
## Summary
- add a components island that opens a creation modal inspired by the definitions flow
- render a reusable component creation form template and modal styles with live summary updates
- implement PHP endpoints and helpers for component CRUD groundwork and hook HX routing for editor component actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d67ca6fb388327942e9fb45faedcce