### PR TITLE
feat: auto create child components

### DIFF
--- a/server/lib/definitions.php
+++ b/server/lib/definitions.php
@@ -240,6 +240,18 @@ function definitions_children_count(PDO $pdo, ?int $parentId): int {
     return (int) $stmt->fetchColumn();
 }
 
+function definitions_fetch_children(PDO $pdo, int $parentId): array {
+    $stmt = $pdo->prepare(
+        'SELECT id, parent_id, title, position, meta, created_at, updated_at
+           FROM definitions
+          WHERE parent_id = :parent
+          ORDER BY position, id'
+    );
+    $stmt->bindValue(':parent', $parentId, PDO::PARAM_INT);
+    $stmt->execute();
+    return $stmt->fetchAll();
+}
+
 function definitions_move(PDO $pdo, int $id, ?int $newParentId, int $newPosition): void {
     $pdo->beginTransaction();
     try {


### PR DESCRIPTION
## Summary
- refactor component insertion to normalise media data and share position handling
- automatically seed child components for definitions that include nested definitions
- expose a helper to fetch definition children for component seeding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db871030b48327a9235755c623a0e2