### PR TITLE
fix: align island styles with lint rules

### DIFF
--- a/server/views/demo.php
+++ b/server/views/demo.php
@@ -47,22 +47,22 @@
       <div>
         <label>Vyberte roli</label>
         <div class="select" data-select data-value="user">
-          <button type="button" class="select__button" aria-haspopup="listbox" aria-expanded="false">user</button>
-          <ul class="select__list" role="listbox" hidden>
-            <li role="option" class="select__option" data-value="user" aria-selected="true">user</li>
-            <li role="option" class="select__option" data-value="admin" aria-selected="false">admin</li>
-            <li role="option" class="select__option" data-value="superadmin" aria-selected="false">superadmin</li>
+          <button type="button" class="select-button" aria-haspopup="listbox" aria-expanded="false">user</button>
+          <ul class="select-list" role="listbox" hidden>
+            <li role="option" class="select-option" data-value="user" aria-selected="true">user</li>
+            <li role="option" class="select-option" data-value="admin" aria-selected="false">admin</li>
+            <li role="option" class="select-option" data-value="superadmin" aria-selected="false">superadmin</li>
           </ul>
         </div>
       </div>
       <div>
         <label>Jednoduchý výběr</label>
         <div class="select" data-select data-value="Option A">
-          <button type="button" class="select__button" aria-haspopup="listbox" aria-expanded="false">Option A</button>
-          <ul class="select__list" role="listbox" hidden>
-            <li role="option" class="select__option" data-value="Option A" aria-selected="true">Option A</li>
-            <li role="option" class="select__option" data-value="Option B" aria-selected="false">Option B</li>
-            <li role="option" class="select__option" data-value="Option C" aria-selected="false">Option C</li>
+          <button type="button" class="select-button" aria-haspopup="listbox" aria-expanded="false">Option A</button>
+          <ul class="select-list" role="listbox" hidden>
+            <li role="option" class="select-option" data-value="Option A" aria-selected="true">Option A</li>
+            <li role="option" class="select-option" data-value="Option B" aria-selected="false">Option B</li>
+            <li role="option" class="select-option" data-value="Option C" aria-selected="false">Option C</li>
           </ul>
         </div>
       </div>

--- a/server/views/editor/partials/components-create-form.php
+++ b/server/views/editor/partials/components-create-form.php
@@ -29,16 +29,16 @@ $parentPlaceholder = 'Kořenová komponenta';
         >
           <button
             type="button"
-            class="select__button"
+            class="select-button"
             id="component-modal-definition-button"
             aria-haspopup="listbox"
             aria-expanded="false"
             aria-labelledby="component-modal-definition-label component-modal-definition-button"
           ><?= htmlspecialchars($definitionPlaceholder, ENT_QUOTES, 'UTF-8') ?></button>
-          <ul class="select__list" role="listbox" tabindex="-1" hidden>
+          <ul class="select-list" role="listbox" tabindex="-1" hidden>
             <li
               role="option"
-              class="select__option"
+              class="select-option"
               data-value=""
               data-label="<?= htmlspecialchars($definitionPlaceholder, ENT_QUOTES, 'UTF-8') ?>"
               aria-selected="true"
@@ -54,7 +54,7 @@ $parentPlaceholder = 'Kořenová komponenta';
               ?>
               <li
                 role="option"
-                class="select__option"
+                class="select-option"
                 data-value="<?= $id ?>"
                 data-label="<?= htmlspecialchars($labelText, ENT_QUOTES, 'UTF-8') ?>"
                 aria-selected="false"
@@ -88,16 +88,16 @@ $parentPlaceholder = 'Kořenová komponenta';
         >
           <button
             type="button"
-            class="select__button"
+            class="select-button"
             id="component-modal-parent-button"
             aria-haspopup="listbox"
             aria-expanded="false"
             aria-labelledby="component-modal-parent-label component-modal-parent-button"
           ><?= htmlspecialchars($parentPlaceholder, ENT_QUOTES, 'UTF-8') ?></button>
-          <ul class="select__list" role="listbox" tabindex="-1" hidden>
+          <ul class="select-list" role="listbox" tabindex="-1" hidden>
             <li
               role="option"
-              class="select__option"
+              class="select-option"
               data-value=""
               data-label="<?= htmlspecialchars($parentPlaceholder, ENT_QUOTES, 'UTF-8') ?>"
               aria-selected="true"
@@ -113,7 +113,7 @@ $parentPlaceholder = 'Kořenová komponenta';
               ?>
               <li
                 role="option"
-                class="select__option"
+                class="select-option"
                 data-value="<?= $id ?>"
                 data-label="<?= htmlspecialchars($labelText, ENT_QUOTES, 'UTF-8') ?>"
                 aria-selected="false"

--- a/server/views/editor/partials/components.php
+++ b/server/views/editor/partials/components.php
@@ -289,7 +289,7 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
 
   .component-form--modal input:not([type="hidden"]):focus,
   .component-form--modal textarea:focus,
-  .component-form--modal .select__button:focus {
+  .component-form--modal .select-button:focus {
     outline: 2px solid var(--primary);
     outline-offset: 1px
   }
@@ -405,7 +405,7 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     width: 100%
   }
 
-  .component-select[data-select-invalid] .select__button {
+  .component-select[data-select-invalid] .select-button {
     border-color: #dc2626
   }
 </style>

--- a/server/views/editor/partials/definitions-parent-select.php
+++ b/server/views/editor/partials/definitions-parent-select.php
@@ -16,9 +16,9 @@ if ($selectedParent !== null) {
 ?>
 <input type="hidden" id="definition-parent-value" name="parent_id" value="<?= htmlspecialchars($currentValue, ENT_QUOTES, 'UTF-8') ?>">
 <div class="select" data-select data-value="<?= htmlspecialchars($currentValue, ENT_QUOTES, 'UTF-8') ?>" data-label="<?= htmlspecialchars($currentLabel, ENT_QUOTES, 'UTF-8') ?>">
-  <button type="button" class="select__button" id="definition-parent-button" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="definition-parent-label definition-parent-button"><?= htmlspecialchars($currentLabel, ENT_QUOTES, 'UTF-8') ?></button>
-  <ul class="select__list" role="listbox" tabindex="-1" hidden>
-    <li role="option" class="select__option" data-value="" data-label="<?= htmlspecialchars($rootLabel, ENT_QUOTES, 'UTF-8') ?>" aria-selected="<?= $currentValue === '' ? 'true' : 'false' ?>"><?= htmlspecialchars($rootLabel, ENT_QUOTES, 'UTF-8') ?></li>
+  <button type="button" class="select-button" id="definition-parent-button" aria-haspopup="listbox" aria-expanded="false" aria-labelledby="definition-parent-label definition-parent-button"><?= htmlspecialchars($currentLabel, ENT_QUOTES, 'UTF-8') ?></button>
+  <ul class="select-list" role="listbox" tabindex="-1" hidden>
+    <li role="option" class="select-option" data-value="" data-label="<?= htmlspecialchars($rootLabel, ENT_QUOTES, 'UTF-8') ?>" aria-selected="<?= $currentValue === '' ? 'true' : 'false' ?>"><?= htmlspecialchars($rootLabel, ENT_QUOTES, 'UTF-8') ?></li>
     <?php foreach ($flat as $item): ?>
       <?php
         $value = (string) $item['id'];
@@ -27,7 +27,7 @@ if ($selectedParent !== null) {
         $display = $indent . $label;
         $selected = $value === $currentValue ? 'true' : 'false';
       ?>
-      <li role="option" class="select__option" data-value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>" data-label="<?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>" aria-selected="<?= $selected ?>"><?= htmlspecialchars($display, ENT_QUOTES, 'UTF-8') ?></li>
+      <li role="option" class="select-option" data-value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>" data-label="<?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>" aria-selected="<?= $selected ?>"><?= htmlspecialchars($display, ENT_QUOTES, 'UTF-8') ?></li>
     <?php endforeach; ?>
   </ul>
 </div>

--- a/server/views/editor/partials/definitions.php
+++ b/server/views/editor/partials/definitions.php
@@ -111,8 +111,8 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
   .definition-form--modal fieldset{border:0;padding:0;margin:0;display:flex;flex-direction:column;gap:.75rem}
   .definition-field{display:flex;flex-direction:column;gap:.35rem}
   .definition-field label{font-weight:600;font-size:.9rem}
-  .definition-form--modal input,.definition-form--modal .select__button{border:1px solid var(--fg);border-radius:.35rem;padding:.4rem .5rem;font:inherit;background:transparent;color:inherit;width:100%;text-align:left}
-  .definition-form--modal input:focus,.definition-form--modal .select__button:focus{outline:2px solid var(--primary);outline-offset:1px}
-  .definition-form--modal .select__button:hover,.definition-form--modal .select__button:focus-visible{background:var(--primary);color:var(--primary-contrast)}
+  .definition-form--modal input,.definition-form--modal .select-button{border:1px solid var(--fg);border-radius:.35rem;padding:.4rem .5rem;font:inherit;background:transparent;color:inherit;width:100%;text-align:left}
+  .definition-form--modal input:focus,.definition-form--modal .select-button:focus{outline:2px solid var(--primary);outline-offset:1px}
+  .definition-form--modal .select-button:hover,.definition-form--modal .select-button:focus-visible{background:var(--primary);color:var(--primary-contrast)}
   .definition-modal-actions{display:flex;justify-content:flex-end;gap:.5rem}
 </style>

--- a/src/islands/components.ts
+++ b/src/islands/components.ts
@@ -92,7 +92,7 @@ const setupComponentForm = (form: HTMLFormElement) => {
         }
 
         const button =
-            selectEl.querySelector<HTMLButtonElement>('.select__button');
+            selectEl.querySelector<HTMLButtonElement>('.select-button');
         const required = selectEl.dataset.required === 'true';
 
         const updateValidity = (value: string) => {
@@ -237,7 +237,7 @@ const setupComponentForm = (form: HTMLFormElement) => {
                 'input[type="hidden"]'
             );
             const button =
-                selectEl.querySelector<HTMLButtonElement>('.select__button');
+                selectEl.querySelector<HTMLButtonElement>('.select-button');
             if (!hiddenInput || !button) {
                 return;
             }
@@ -265,7 +265,7 @@ const getHtmx = (): HTMX | null => {
 
 const focusFirstField = (container: HTMLElement) => {
     const field = container.querySelector<HTMLElement>(
-        'button.select__button, input:not([type="hidden"]), textarea, select'
+        'button.select-button, input:not([type="hidden"]), textarea, select'
     );
     field?.focus();
 };

--- a/src/islands/images.css
+++ b/src/islands/images.css
@@ -1,5 +1,56 @@
 /* Scoped styles for images island: modal, context menu, drag ghost */
 
+.drag-ghost {
+    position: fixed;
+    inset: 0 auto auto 0;
+    pointer-events: none;
+    user-select: none;
+    background: var(--bg, #111);
+    color: var(--fg, #fff);
+    border: 1px dashed var(--primary, #2563eb);
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 25%);
+    transform: translate(-9999px, -9999px);
+    will-change: transform;
+    white-space: nowrap;
+    z-index: 2147483647; /* ensure on top of everything */
+    mix-blend-mode: normal;
+}
+
+.drag-ghost-content {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.drag-ghost-thumb {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 0.25rem;
+    background: rgb(0 0 0 / 6%);
+}
+
+.drag-ghost-thumb img {
+    max-width: 100%;
+    max-height: 100%;
+    display: block;
+}
+
+.drag-ghost-thumb svg {
+    width: 32px;
+    height: 32px;
+    display: block;
+}
+
+.drag-ghost-label {
+    font-weight: 500;
+}
+
 #img-modal {
     position: fixed;
     inset: 0;
@@ -104,57 +155,6 @@
     background: var(--primary);
     color: #fff;
     outline: none;
-}
-
-.drag-ghost {
-    position: fixed;
-    inset: 0 auto auto 0;
-    pointer-events: none;
-    user-select: none;
-    background: var(--bg, #111);
-    color: var(--fg, #fff);
-    border: 1px dashed var(--primary, #2563eb);
-    border-radius: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    box-shadow: 0 2px 8px rgb(0 0 0 / 25%);
-    transform: translate(-9999px, -9999px);
-    will-change: transform;
-    white-space: nowrap;
-    z-index: 2147483647; /* ensure on top of everything */
-    mix-blend-mode: normal;
-}
-
-.drag-ghost__content {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.drag-ghost__thumb {
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
-    border-radius: 0.25rem;
-    background: rgb(0 0 0 / 6%);
-}
-
-.drag-ghost__thumb img {
-    max-width: 100%;
-    max-height: 100%;
-    display: block;
-}
-
-.drag-ghost__thumb svg {
-    width: 32px;
-    height: 32px;
-    display: block;
-}
-
-.drag-ghost__label {
-    font-weight: 500;
 }
 
 /* Subtle UX hint while dragging */

--- a/src/islands/images.ts
+++ b/src/islands/images.ts
@@ -433,10 +433,10 @@ function mount(el: HTMLElement) {
         const g = document.createElement('div');
         g.className = 'drag-ghost';
         const content = document.createElement('div');
-        content.className = 'drag-ghost__content';
+        content.className = 'drag-ghost-content';
 
         const thumbWrap = document.createElement('div');
-        thumbWrap.className = 'drag-ghost__thumb';
+        thumbWrap.className = 'drag-ghost-thumb';
         const thumbEl =
             (from.querySelector('.thumb img') as HTMLElement | null) ||
             (from.querySelector('.thumb svg') as HTMLElement | null);
@@ -460,7 +460,7 @@ function mount(el: HTMLElement) {
         }
 
         const label = document.createElement('span');
-        label.className = 'drag-ghost__label';
+        label.className = 'drag-ghost-label';
         label.textContent =
             qs<HTMLElement>(from, '.label')?.textContent || 'Přesunout';
 

--- a/src/islands/select.css
+++ b/src/islands/select.css
@@ -5,7 +5,7 @@
     min-width: 8rem;
 }
 
-.select__button {
+.select-button {
     width: 100%;
     text-align: left;
     background: var(--bg);
@@ -16,19 +16,19 @@
     cursor: pointer;
 }
 
-.select__button:hover,
-.select__button:focus-visible {
+.select-button:hover,
+.select-button:focus-visible {
     background: var(--primary-hover);
     color: #fff;
 }
 
-.select__button::after {
+.select-button::after {
     content: '\25BE';
     float: right;
     opacity: 0.7;
 }
 
-.select__list {
+.select-list {
     position: absolute;
     inset: auto 0;
     top: calc(100% + 2px);
@@ -45,27 +45,27 @@
     padding: 0;
 }
 
-.select__list[hidden] {
+.select-list[hidden] {
     display: none;
 }
 
-.select__option {
+.select-option {
     padding: 0.25rem 0.5rem;
     cursor: pointer;
 }
 
-.select__option[aria-selected='true'] {
+.select-option[aria-selected='true'] {
     font-weight: 600;
 }
 
-.select__option:hover,
-.select__option[data-active] {
+.select-option:hover,
+.select-option[data-active] {
     background: var(--primary-hover);
     color: #fff;
 }
 
-html[data-theme='dark'] .select__button:hover,
-.select__option:hover {
+html[data-theme='dark'] .select-button:hover,
+.select-option:hover {
     color: var(--primary-contrast);
 }
 

--- a/src/islands/select.ts
+++ b/src/islands/select.ts
@@ -1,11 +1,11 @@
 import './select.css';
 
 export function setSelectValue(sel: HTMLElement, value: string) {
-    const btn = sel.querySelector<HTMLButtonElement>('.select__button');
-    const list = sel.querySelector<HTMLUListElement>('.select__list');
+    const btn = sel.querySelector<HTMLButtonElement>('.select-button');
+    const list = sel.querySelector<HTMLUListElement>('.select-list');
     if (!btn || !list) return;
     const options = Array.from(
-        list.querySelectorAll<HTMLLIElement>('.select__option')
+        list.querySelectorAll<HTMLLIElement>('.select-option')
     );
     let label = value;
     options.forEach((o) => {
@@ -27,8 +27,8 @@ export function enhanceSelects(root: Document | HTMLElement = document) {
 
     const closeAll = () => {
         selects.forEach((s) => {
-            const btn = s.querySelector<HTMLButtonElement>('.select__button');
-            const list = s.querySelector<HTMLUListElement>('.select__list');
+            const btn = s.querySelector<HTMLButtonElement>('.select-button');
+            const list = s.querySelector<HTMLUListElement>('.select-list');
             if (btn && list) {
                 btn.setAttribute('aria-expanded', 'false');
                 list.hidden = true;
@@ -42,11 +42,11 @@ export function enhanceSelects(root: Document | HTMLElement = document) {
     });
 
     selects.forEach((sel) => {
-        const btn = sel.querySelector<HTMLButtonElement>('.select__button');
-        const list = sel.querySelector<HTMLUListElement>('.select__list');
+        const btn = sel.querySelector<HTMLButtonElement>('.select-button');
+        const list = sel.querySelector<HTMLUListElement>('.select-list');
         if (!btn || !list) return;
         const options = Array.from(
-            list.querySelectorAll<HTMLLIElement>('.select__option')
+            list.querySelectorAll<HTMLLIElement>('.select-option')
         );
 
         const initialAttr = sel.getAttribute('data-value');

--- a/src/islands/users.ts
+++ b/src/islands/users.ts
@@ -26,11 +26,11 @@ export default async function init(el: HTMLElement) {
                 const roleCell =
                     canEdit && !isSelf
                         ? `<div class="select" data-select data-user-id="${u.id}" data-prev="${role}">
-                          <button type="button" class="select__button" aria-haspopup="listbox" aria-expanded="false">${role}</button>
-                          <ul class="select__list" role="listbox" tabindex="-1" hidden>
-                            <li role="option" class="select__option" data-value="user" aria-selected="${role === 'user'}">user</li>
-                            <li role="option" class="select__option" data-value="admin" aria-selected="${role === 'admin'}">admin</li>
-                            <li role="option" class="select__option" data-value="superadmin" aria-selected="${role === 'superadmin'}">superadmin</li>
+                          <button type="button" class="select-button" aria-haspopup="listbox" aria-expanded="false">${role}</button>
+                          <ul class="select-list" role="listbox" tabindex="-1" hidden>
+                            <li role="option" class="select-option" data-value="user" aria-selected="${role === 'user'}">user</li>
+                            <li role="option" class="select-option" data-value="admin" aria-selected="${role === 'admin'}">admin</li>
+                            <li role="option" class="select-option" data-value="superadmin" aria-selected="${role === 'superadmin'}">superadmin</li>
                           </ul>
                        </div>`
                         : role +


### PR DESCRIPTION
## Summary
- rename drag ghost and custom select classes to hyphenated names that satisfy the CSS selector lint pattern
- reorder the drag ghost styles ahead of modal rules to avoid descending-specificity warnings
- update TypeScript and PHP templates to use the new class names so functionality stays in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbcbeead388327883bda1a9663ff40