### PR TITLE
fix: normalize CSS class names for stylelint compliance

### DIFF
--- a/server/views/demo.php
+++ b/server/views/demo.php
@@ -32,9 +32,9 @@
 <section>
   <h2>Formulář</h2>
   <form class="auth-form">
-    <div class="auth-form__field">
+    <div class="auth-form-field">
       <label for="demo-input">Vstup</label>
-      <input id="demo-input" type="text" class="auth-form__input" placeholder="Textový vstup" />
+      <input id="demo-input" type="text" class="auth-form-input" placeholder="Textový vstup" />
     </div>
     <button type="submit">Odeslat</button>
   </form>

--- a/server/views/editor/partials/components-tree.php
+++ b/server/views/editor/partials/components-tree.php
@@ -51,8 +51,8 @@ if (!function_exists('render_component_nodes')) {
 
             echo '<li class="component-item" data-id="' . $id . '" data-parent="' . htmlspecialchars($parentId, ENT_QUOTES, 'UTF-8') . '" data-position="' . $position . '" data-path="' . htmlspecialchars($nodePath, ENT_QUOTES, 'UTF-8') . '" data-children-count="' . $childCount . '" data-definition-id="' . $definitionId . '">';
             echo '<div class="component-node">';
-            echo '<div class="component-node__header">';
-            echo '<div class="component-node__info">';
+            echo '<div class="component-node-header">';
+            echo '<div class="component-node-info">';
             echo '<strong>' . $effectiveTitle . '</strong>';
             if ($alternateTitle !== '') {
                 echo '<span class="component-alias">alias "' . $alternateTitle . '"</span>';
@@ -67,7 +67,7 @@ if (!function_exists('render_component_nodes')) {
             echo '</div>';
             $hasDetails = $description !== '' || $image !== '' || $color !== '' || $dependencyCount > 0;
             if ($hasDetails) {
-                echo '<dl class="component-node__details">';
+                echo '<dl class="component-node-details">';
                 if ($description !== '') {
                     echo '<div><dt>Popis</dt><dd>' . $description . '</dd></div>';
                 }

--- a/server/views/editor/partials/components.php
+++ b/server/views/editor/partials/components.php
@@ -130,7 +130,7 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     background: rgb(255 255 255 / 5%)
   }
 
-  .component-node__header {
+  .component-node-header {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
@@ -138,13 +138,13 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     flex-wrap: wrap
   }
 
-  .component-node__info {
+  .component-node-info {
     display: flex;
     flex-direction: column;
     gap: .25rem
   }
 
-  .component-node__info strong {
+  .component-node-info strong {
     font-weight: 600;
     font-size: 1rem
   }
@@ -169,21 +169,21 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     gap: .35rem
   }
 
-  .component-node__details {
+  .component-node-details {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: .5rem;
     margin: 0
   }
 
-  .component-node__details dt {
+  .component-node-details dt {
     font-weight: 600;
     font-size: .75rem;
     color: var(--fg-muted);
     margin-bottom: .2rem
   }
 
-  .component-node__details dd {
+  .component-node-details dd {
     margin: 0;
     font-size: .85rem
   }
@@ -203,14 +203,14 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     display: none
   }
 
-  .components-modal__overlay {
+  .components-modal-overlay {
     position: absolute;
     inset: 0;
     background: transparent;
     cursor: pointer
   }
 
-  .components-modal__panel {
+  .components-modal-panel {
     position: relative;
     background: var(--bg);
     color: var(--fg);
@@ -225,19 +225,19 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     z-index: 1
   }
 
-  .components-modal__panel header {
+  .components-modal-panel header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: .5rem
   }
 
-  .components-modal__panel header h3 {
+  .components-modal-panel header h3 {
     margin: 0;
     font-size: 1.1rem
   }
 
-  .components-modal__panel header button {
+  .components-modal-panel header button {
     border: none;
     background: transparent;
     color: inherit;
@@ -245,7 +245,7 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     cursor: pointer
   }
 
-  .components-modal__body {
+  .components-modal-body {
     display: flex;
     flex-direction: column;
     gap: 1rem

--- a/server/views/editor/partials/definitions.php
+++ b/server/views/editor/partials/definitions.php
@@ -101,11 +101,11 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
   .definitions-empty{font-style:italic;color:#6b7280}
   .definitions-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgb(0 0 0 / 40%);padding:1rem;z-index:2000}
   .definitions-modal.hidden{display:none}
-  .definitions-modal__panel{background:var(--bg);color:var(--fg);border-radius:.5rem;box-shadow:0 12px 32px rgb(0 0 0 / 22%);max-width:420px;width:100%;padding:1rem;display:flex;flex-direction:column;gap:1rem}
-  .definitions-modal__panel header{display:flex;justify-content:space-between;align-items:center;gap:.5rem}
-  .definitions-modal__panel header h3{margin:0;font-size:1.1rem}
-  .definitions-modal__panel header button{border:none;background:transparent;color:inherit;font-size:1.2rem;cursor:pointer}
-  .definitions-modal__body{display:flex;flex-direction:column;gap:1rem}
+  .definitions-modal-panel{background:var(--bg);color:var(--fg);border-radius:.5rem;box-shadow:0 12px 32px rgb(0 0 0 / 22%);max-width:420px;width:100%;padding:1rem;display:flex;flex-direction:column;gap:1rem}
+  .definitions-modal-panel header{display:flex;justify-content:space-between;align-items:center;gap:.5rem}
+  .definitions-modal-panel header h3{margin:0;font-size:1.1rem}
+  .definitions-modal-panel header button{border:none;background:transparent;color:inherit;font-size:1.2rem;cursor:pointer}
+  .definitions-modal-body{display:flex;flex-direction:column;gap:1rem}
   .definition-modal-body{display:flex;flex-direction:column;gap:1rem}
   .definition-form--modal{display:flex;flex-direction:column;gap:.75rem}
   .definition-form--modal fieldset{border:0;padding:0;margin:0;display:flex;flex-direction:column;gap:.75rem}

--- a/server/views/layout.php
+++ b/server/views/layout.php
@@ -73,8 +73,8 @@ function vite_asset(string $entry) {
       main{padding:1rem;padding-top:3.5rem;min-height:100dvb;max-width:1000px;margin:0 auto}
       .hidden{display:none}
       .auth-form{display:flex;flex-direction:column;align-items:center;gap:0.5rem;max-width:300px;margin:0 auto}
-      .auth-form__field{display:flex;flex-direction:column;width:100%}
-      .auth-form__input{width:100%;padding:.5rem;border:1px solid var(--fg);border-radius:.25rem}
+      .auth-form-field{display:flex;flex-direction:column;width:100%}
+      .auth-form-input{width:100%;padding:.5rem;border:1px solid var(--fg);border-radius:.25rem}
       .auth-form button{width:100%;font-size:1.1rem;margin-top:1rem}
       .app-version-badge{position:fixed;bottom:1rem;left:1rem;display:flex;align-items:center;gap:.4rem;background:color-mix(in srgb, var(--bg) 85%, var(--fg));color:var(--fg);padding:.4rem .6rem;border-radius:.75rem;border:1px solid color-mix(in srgb, var(--fg) 20%, transparent);box-shadow:0 4px 12px rgb(0 0 0 / 8%);font-size:.75rem;line-height:1;z-index:1000;pointer-events:none}
       .app-version-dot{width:.5rem;height:.5rem;border-radius:999px;background:var(--primary);box-shadow:0 0 0 3px color-mix(in srgb, var(--primary) 35%, transparent);display:block}

--- a/server/views/login.php
+++ b/server/views/login.php
@@ -1,24 +1,24 @@
 <div data-island="login">
     <h1>Přihlášení</h1>
     <form id="login-form" class="auth-form">
-        <label class="auth-form__field">
+        <label class="auth-form-field">
             E‑mail
             <input
                 type="email"
                 name="email"
                 required
                 autocomplete="username"
-                class="auth-form__input"
+                class="auth-form-input"
             />
         </label>
-        <label class="auth-form__field">
+        <label class="auth-form-field">
             Heslo
             <input
                 type="password"
                 name="password"
                 required
                 autocomplete="current-password"
-                class="auth-form__input"
+                class="auth-form-input"
             />
         </label>
         <button type="submit">PŘIHLÁSIT SE</button>

--- a/server/views/register.php
+++ b/server/views/register.php
@@ -1,34 +1,34 @@
 <div data-island="register">
     <h1>Registrace</h1>
     <form id="register-form" class="auth-form">
-        <label class="auth-form__field">
+        <label class="auth-form-field">
             Uživatelské jméno
             <input
                 type="text"
                 name="username"
                 required
                 autocomplete="username"
-                class="auth-form__input"
+                class="auth-form-input"
             />
         </label>
-        <label class="auth-form__field">
+        <label class="auth-form-field">
             E‑mail
             <input
                 type="email"
                 name="email"
                 required
                 autocomplete="email"
-                class="auth-form__input"
+                class="auth-form-input"
             />
         </label>
-        <label class="auth-form__field">
+        <label class="auth-form-field">
             Heslo
             <input
                 type="password"
                 name="password"
                 required
                 autocomplete="new-password"
-                class="auth-form__input"
+                class="auth-form-input"
             />
         </label>
         <button type="submit">REGISTROVAT SE</button>

--- a/src/islands/components.ts
+++ b/src/islands/components.ts
@@ -324,7 +324,7 @@ export default function init(root: HTMLElement) {
             return;
         }
         const panel = bodyContainer.closest(
-            '.components-modal__panel'
+            '.components-modal-panel'
         ) as HTMLElement | null;
         if (!panel || panel.contains(errorBox)) {
             return;
@@ -348,17 +348,17 @@ export default function init(root: HTMLElement) {
 
     const openModal = (title: string, body: HTMLElement) => {
         modalRoot.innerHTML = `
-            <div class="components-modal__overlay" data-modal-close></div>
-            <div class="components-modal__panel" role="dialog" aria-modal="true">
+            <div class="components-modal-overlay" data-modal-close></div>
+            <div class="components-modal-panel" role="dialog" aria-modal="true">
               <header>
                 <h3>${escapeHtml(title)}</h3>
                 <button type="button" class="component-action" data-modal-close aria-label="Zavřít">×</button>
               </header>
-              <div class="components-modal__body"></div>
+              <div class="components-modal-body"></div>
             </div>
         `;
         const bodyContainer = modalRoot.querySelector(
-            '.components-modal__body'
+            '.components-modal-body'
         ) as HTMLElement | null;
         if (!bodyContainer) {
             return;

--- a/src/islands/definitions-tree.ts
+++ b/src/islands/definitions-tree.ts
@@ -518,18 +518,18 @@ export default function init(el: HTMLElement) {
         if (!modalRoot) return;
 
         modalRoot.innerHTML = `
-            <div class="definitions-modal__overlay" data-modal-close></div>
-            <div class="definitions-modal__panel" role="dialog" aria-modal="true">
+            <div class="definitions-modal-overlay" data-modal-close></div>
+            <div class="definitions-modal-panel" role="dialog" aria-modal="true">
               <header>
                 <h3>${escapeHtml(title)}</h3>
                 <button type="button" class="definition-action" data-modal-close aria-label="Zavřít">×</button>
               </header>
-              <div class="definitions-modal__body"></div>
+              <div class="definitions-modal-body"></div>
             </div>
         `;
 
         const bodyContainer = modalRoot.querySelector(
-            '.definitions-modal__body'
+            '.definitions-modal-body'
         ) as HTMLElement;
 
         bodyContainer.appendChild(body);

--- a/tmp_layout.php
+++ b/tmp_layout.php
@@ -47,8 +47,8 @@ function vite_asset(string $entry) {
       main{padding:1rem;padding-top:3.5rem;min-height:100dvb;max-width:800px;margin:0 auto}
       .hidden{display:none}
       .auth-form{display:flex;flex-direction:column;align-items:center;gap:0.5rem;max-width:300px;margin:0 auto}
-      .auth-form__field{display:flex;flex-direction:column;width:100%}
-      .auth-form__input{width:100%;padding:.5rem;border:1px solid var(--fg);border-radius:.25rem}
+      .auth-form-field{display:flex;flex-direction:column;width:100%}
+      .auth-form-input{width:100%;padding:.5rem;border:1px solid var(--fg);border-radius:.25rem}
       .auth-form button{width:100%;font-size:1.1rem;margin-top:1rem}
     </style>
     <?php if (APP_ENV !== 'dev'):


### PR DESCRIPTION
## Summary
- rename auth form classes to hyphenated form to satisfy the selector-class-pattern rule
- update component tree and modal class names plus related TypeScript selectors to match the lint pattern

## Testing
- npm run lint *(fails: stylelint: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdfa76c7883278fa4bfacda21c44f