### PR TITLE
feat: add component price entry and history preview

### DIFF
--- a/server/views/editor/components-create.php
+++ b/server/views/editor/components-create.php
@@ -33,6 +33,7 @@ $image = isset($_POST['image']) ? trim((string) $_POST['image']) : '';
 $color = isset($_POST['color']) ? trim((string) $_POST['color']) : '';
 $mediaType = isset($_POST['media_type']) ? (string) $_POST['media_type'] : 'image';
 $positionParam = isset($_POST['position']) ? trim((string) $_POST['position']) : '';
+$priceParam = isset($_POST['price']) ? trim((string) $_POST['price']) : '';
 
 $mediaType = $mediaType === 'color' ? 'color' : 'image';
 
@@ -40,6 +41,7 @@ $errors = [];
 $definitionId = null;
 $parentId = null;
 $position = null;
+$priceValue = null;
 
 if ($definitionParam === '' || !preg_match('/^\d+$/', (string) $definitionParam)) {
     $errors[] = 'Vyberte prosím platnou definici.';
@@ -94,6 +96,11 @@ if ($positionParam !== '') {
     }
 }
 
+[$priceValue, $priceError] = components_normalise_price_input($priceParam);
+if ($priceError !== null) {
+    $errors[] = $priceError;
+}
+
 if (!empty($errors)) {
     http_response_code(422);
     components_render_fragments($pdo, [
@@ -125,7 +132,9 @@ try {
         $description !== '' ? $description : null,
         $image !== '' ? $image : null,
         $color !== '' ? strtoupper($color) : null,
-        $position
+        $position,
+        $priceValue,
+        'CZK'
     );
     http_response_code(201);
     components_render_fragments($pdo, [

--- a/server/views/editor/components-update.php
+++ b/server/views/editor/components-update.php
@@ -34,6 +34,7 @@ $image = isset($_POST['image']) ? trim((string) $_POST['image']) : '';
 $color = isset($_POST['color']) ? trim((string) $_POST['color']) : '';
 $mediaType = isset($_POST['media_type']) ? (string) $_POST['media_type'] : 'image';
 $positionParam = isset($_POST['position']) ? trim((string) $_POST['position']) : '';
+$priceParam = isset($_POST['price']) ? trim((string) $_POST['price']) : '';
 
 $mediaType = $mediaType === 'color' ? 'color' : 'image';
 
@@ -42,6 +43,7 @@ $componentId = null;
 $definitionId = null;
 $parentId = null;
 $position = null;
+$priceValue = null;
 
 if ($componentParam === '' || !preg_match('/^\d+$/', (string) $componentParam)) {
     $errors[] = 'Vyberte prosím platnou komponentu.';
@@ -118,6 +120,11 @@ if ($positionParam !== '') {
     }
 }
 
+[$priceValue, $priceError] = components_normalise_price_input($priceParam);
+if ($priceError !== null) {
+    $errors[] = $priceError;
+}
+
 if (!empty($errors)) {
     http_response_code(422);
     components_render_fragments($pdo, [
@@ -146,7 +153,9 @@ try {
         $description !== '' ? $description : null,
         $image !== '' ? $image : null,
         $color !== '' ? strtoupper($color) : null,
-        $position
+        $position,
+        $priceValue,
+        'CZK'
     );
     components_render_fragments($pdo, [
         'message' => 'Komponenta byla aktualizována.',

--- a/server/views/editor/partials/components-create-form.php
+++ b/server/views/editor/partials/components-create-form.php
@@ -145,6 +145,28 @@ $parentPlaceholder = 'Kořenová komponenta';
         placeholder="Krátký popis komponenty"
       ></textarea>
     </div>
+    <div class="component-field component-field--price">
+      <label for="component-modal-price">Cena</label>
+      <div class="component-price-input">
+        <input
+          type="text"
+          id="component-modal-price"
+          name="price"
+          inputmode="decimal"
+          autocomplete="off"
+          placeholder="např. 2499,00"
+          data-price-input
+        >
+        <span class="component-price-suffix" data-price-currency>CZK</span>
+      </div>
+      <p class="component-help">Volitelné. Zadejte cenu s DPH ve formátu 1234,56 (max. dvě desetinná místa).</p>
+      <div class="component-price-history" data-price-history-wrapper>
+        <span class="component-price-history-label">Historie cen</span>
+        <ul class="component-price-history-list" data-price-history-list>
+          <li class="component-price-history-empty" data-empty-state>Žádné záznamy.</li>
+        </ul>
+      </div>
+    </div>
     <div class="component-field component-field--media">
       <span class="component-media-label">Reprezentace</span>
       <div class="component-media-toggle" data-media-toggle>

--- a/server/views/editor/partials/components-tree.php
+++ b/server/views/editor/partials/components-tree.php
@@ -42,6 +42,24 @@ if (!function_exists('render_component_nodes')) {
             $childCount = is_array($children) ? count($children) : 0;
             $nodePath = ltrim(($path === '' ? '' : $path . '/') . $id, '/');
             $mediaType = $rawColor !== '' ? 'color' : 'image';
+            $latestPrice = isset($node['latest_price']) && is_array($node['latest_price'])
+                ? $node['latest_price']
+                : null;
+            $latestAmountRaw = $latestPrice !== null && isset($latestPrice['amount'])
+                ? (string) $latestPrice['amount']
+                : '';
+            $latestCurrencyRaw = $latestPrice !== null && isset($latestPrice['currency'])
+                ? (string) $latestPrice['currency']
+                : 'CZK';
+            $latestCurrency = strtoupper($latestCurrencyRaw);
+            $priceHistory = isset($node['price_history']) && is_array($node['price_history'])
+                ? array_slice($node['price_history'], 0, 10)
+                : [];
+            $priceHistoryJsonRaw = json_encode($priceHistory, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            if ($priceHistoryJsonRaw === false) {
+                $priceHistoryJsonRaw = '[]';
+            }
+            $priceHistoryJson = htmlspecialchars($priceHistoryJsonRaw, ENT_QUOTES, 'UTF-8');
             $metaParts = [
                 'ID ' . $id,
                 'pozice ' . $position,
@@ -61,7 +79,7 @@ if (!function_exists('render_component_nodes')) {
             echo '</div>';
             echo '<div class="component-actions">';
             echo '<button type="button" class="component-action" data-action="create-child" data-parent-id="' . $id . '" data-parent-title="' . $effectiveTitle . '" data-parent-children="' . $childCount . '">Přidat podkomponentu</button>';
-            echo '<button type="button" class="component-action" data-action="edit" data-component-id="' . $id . '" data-title="' . $effectiveTitle . '" data-definition-id="' . $definitionId . '" data-alternate-title="' . htmlspecialchars($rawAlternateTitle, ENT_QUOTES, 'UTF-8') . '" data-description="' . htmlspecialchars($rawDescription, ENT_QUOTES, 'UTF-8') . '" data-image="' . htmlspecialchars($rawImage, ENT_QUOTES, 'UTF-8') . '" data-color="' . htmlspecialchars($rawColor, ENT_QUOTES, 'UTF-8') . '" data-media-type="' . $mediaType . '" data-position="' . $position . '">Upravit</button>';
+            echo '<button type="button" class="component-action" data-action="edit" data-component-id="' . $id . '" data-title="' . $effectiveTitle . '" data-definition-id="' . $definitionId . '" data-alternate-title="' . htmlspecialchars($rawAlternateTitle, ENT_QUOTES, 'UTF-8') . '" data-description="' . htmlspecialchars($rawDescription, ENT_QUOTES, 'UTF-8') . '" data-image="' . htmlspecialchars($rawImage, ENT_QUOTES, 'UTF-8') . '" data-color="' . htmlspecialchars($rawColor, ENT_QUOTES, 'UTF-8') . '" data-media-type="' . $mediaType . '" data-position="' . $position . '" data-price-amount="' . htmlspecialchars($latestAmountRaw, ENT_QUOTES, 'UTF-8') . '" data-price-currency="' . htmlspecialchars($latestCurrency, ENT_QUOTES, 'UTF-8') . '" data-price-history="' . $priceHistoryJson . '">Upravit</button>';
             echo '<button type="button" class="component-action component-action--danger" data-action="delete" data-id="' . $id . '" data-title="' . $effectiveTitle . '">Smazat</button>';
             echo '</div>';
             echo '</div>';

--- a/server/views/editor/partials/components.php
+++ b/server/views/editor/partials/components.php
@@ -277,6 +277,84 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     font-size: .9rem
   }
 
+  .component-field--price {
+    gap: .5rem;
+  }
+
+  .component-price-input {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    max-width: 320px;
+  }
+
+  .component-price-input input {
+    flex: 1;
+    text-align: right;
+  }
+
+  .component-price-suffix {
+    font-weight: 600;
+    font-size: .9rem;
+  }
+
+  .component-price-history {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+  }
+
+  .component-price-history-label {
+    font-size: .75rem;
+    font-weight: 600;
+    color: var(--fg-muted, #6b7280);
+    text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+
+  [data-theme="dark"] .component-price-history-label {
+    color: var(--fg-muted, #94a3b8);
+  }
+
+  .component-price-history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+  }
+
+  .component-price-history-item {
+    display: flex;
+    justify-content: space-between;
+    gap: .75rem;
+    font-size: .85rem;
+  }
+
+  .component-price-history-amount {
+    font-weight: 600;
+  }
+
+  .component-price-history-item time {
+    font-size: .8rem;
+    color: var(--fg-muted, #6b7280);
+  }
+
+  [data-theme="dark"] .component-price-history-item time {
+    color: var(--fg-muted, #cbd5e1);
+  }
+
+  .component-price-history-empty {
+    font-size: .85rem;
+    font-style: italic;
+    color: var(--fg-muted, #6b7280);
+  }
+
+  [data-theme="dark"] .component-price-history-empty {
+    color: var(--fg-muted, #94a3b8);
+  }
+
   .component-form--modal input:not([type="hidden"]),
   .component-form--modal textarea {
     border: 1px solid var(--fg);


### PR DESCRIPTION
## Summary
- add a price field and price history preview to the component modal template and island logic
- persist new component price entries and surface price history data from the backend
- style the modal to accommodate the new price controls and history list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcd359817883278bcfa8d558a82e2d