### PR TITLE
fix: arrange component modal fields in two columns

### DIFF
--- a/server/views/editor/partials/components-create-form.php
+++ b/server/views/editor/partials/components-create-form.php
@@ -136,7 +136,7 @@ $parentPlaceholder = 'Kořenová komponenta';
       >
       <p class="component-help">Pořadí mezi sourozenci (0 = první). Prázdné pole přidá položku na konec.</p>
     </div>
-    <div class="component-field">
+    <div class="component-field component-field--full">
       <label for="component-modal-description">Popis</label>
       <textarea
         id="component-modal-description"
@@ -145,7 +145,7 @@ $parentPlaceholder = 'Kořenová komponenta';
         placeholder="Krátký popis komponenty"
       ></textarea>
     </div>
-    <div class="component-field component-field--price">
+    <div class="component-field component-field--price component-field--full">
       <label for="component-modal-price">Cena</label>
       <div class="component-price-input">
         <input
@@ -167,7 +167,7 @@ $parentPlaceholder = 'Kořenová komponenta';
         </ul>
       </div>
     </div>
-    <div class="component-field component-field--media">
+    <div class="component-field component-field--media component-field--full">
       <span class="component-media-label">Reprezentace</span>
       <div class="component-media-toggle" data-media-toggle>
         <label><input type="radio" name="media_type" value="image" checked data-media-choice="image"> Obrazek</label>

--- a/server/views/editor/partials/components.php
+++ b/server/views/editor/partials/components.php
@@ -261,9 +261,26 @@ $definitionsFlat = definitions_flatten_tree($definitionsTree);
     border: 0;
     padding: 0;
     margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: .75rem
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr)
+  }
+
+  @media (width >= 720px) {
+    .component-form--modal fieldset {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: start
+    }
+  }
+
+  .component-form--modal legend {
+    font-weight: 600;
+    font-size: .95rem;
+    grid-column: 1 / -1
+  }
+
+  .component-field--full {
+    grid-column: 1 / -1
   }
 
   .component-field {


### PR DESCRIPTION
## Summary
- rework the component modal fieldset into a responsive grid so wide viewports split fields into two columns
- add a full-width helper class to keep long description, pricing, and media sections spanning the grid

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcd9e8c8888327ac06edd825586b21