### PR TITLE
fix: centralize PHP bootstrap loading

### DIFF
--- a/server/api/login.php
+++ b/server/api/login.php
@@ -1,10 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/db.php';
-require_once __DIR__ . '/../lib/jwt.php';
-require_once __DIR__ . '/../lib/auth.php';
-require_once __DIR__ . '/../lib/logger.php';
 header('Content-Type: application/json');
 $input = json_decode(file_get_contents('php://input'), true);
 $email = $input['email'] ?? '';

--- a/server/api/logout.php
+++ b/server/api/logout.php
@@ -1,8 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/logger.php';
-require_once __DIR__ . '/../lib/auth.php';
 
 header('Content-Type: application/json');
 

--- a/server/api/me.php
+++ b/server/api/me.php
@@ -1,9 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/db.php';
-require_once __DIR__ . '/../lib/jwt.php';
-require_once __DIR__ . '/../lib/logger.php';
 
 header('Content-Type: application/json');
 

--- a/server/api/refresh.php
+++ b/server/api/refresh.php
@@ -1,10 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/db.php';
-require_once __DIR__ . '/../lib/jwt.php';
-require_once __DIR__ . '/../lib/auth.php';
-require_once __DIR__ . '/../lib/logger.php';
 
 header('Content-Type: application/json');
 

--- a/server/api/register.php
+++ b/server/api/register.php
@@ -1,10 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/db.php';
-require_once __DIR__ . '/../lib/jwt.php';
-require_once __DIR__ . '/../lib/auth.php';
-require_once __DIR__ . '/../lib/logger.php';
 header('Content-Type: application/json');
 $input = json_decode(file_get_contents('php://input'), true);
 $username = $input['username'] ?? '';

--- a/server/api/user-role.php
+++ b/server/api/user-role.php
@@ -1,9 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/db.php';
-require_once __DIR__ . '/../lib/jwt.php';
-require_once __DIR__ . '/../lib/logger.php';
 
 header('Content-Type: application/json');
 

--- a/server/api/users.php
+++ b/server/api/users.php
@@ -1,9 +1,7 @@
 <?php
 
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/cors.php';
-require_once __DIR__ . '/../lib/db.php';
-require_once __DIR__ . '/../lib/jwt.php';
-require_once __DIR__ . '/../lib/logger.php';
 
 header('Content-Type: application/json');
 

--- a/server/bootstrap.php
+++ b/server/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/config/config.php';
+require_once __DIR__ . '/lib/logger.php';
+require_once __DIR__ . '/lib/db.php';
+require_once __DIR__ . '/lib/jwt.php';
+require_once __DIR__ . '/lib/definitions.php';
+require_once __DIR__ . '/lib/components.php';
+require_once __DIR__ . '/lib/auth.php';
+require_once __DIR__ . '/lib/images.php';

--- a/server/index.php
+++ b/server/index.php
@@ -1,8 +1,7 @@
 <?php
 
 // index.php
-require_once __DIR__ . '/config/config.php';
-require_once __DIR__ . '/lib/auth.php';
+require_once __DIR__ . '/bootstrap.php';
 // Resolve route from query-string fallback or pretty URL path
 $qsRoute = isset($_GET['r']) ? trim((string)$_GET['r'], '/') : '';
 if (!$qsRoute || (defined('PRETTY_URLS') && PRETTY_URLS)) {

--- a/server/lib/auth.php
+++ b/server/lib/auth.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once __DIR__ . '/db.php';
-require_once __DIR__ . '/logger.php';
-require_once __DIR__ . '/jwt.php';
-
 function refresh_token_random(): string
 {
     return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');

--- a/server/lib/components.php
+++ b/server/lib/components.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once __DIR__ . '/db.php';
-require_once __DIR__ . '/logger.php';
-require_once __DIR__ . '/definitions.php';
-
 function components_fetch_rows(?PDO $pdo = null): array
 {
 

--- a/server/lib/db-root.php
+++ b/server/lib/db-root.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../config/config.php';
-require_once __DIR__ . '/../config/config-root.php';
-require_once __DIR__ . '/logger.php';
-
 function get_db_root_connection(): PDO
 {
 

--- a/server/lib/db.php
+++ b/server/lib/db.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../config/config.php';
-require_once __DIR__ . '/logger.php';
-
 function get_db_connection(): PDO
 {
 

--- a/server/lib/definitions.php
+++ b/server/lib/definitions.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once __DIR__ . '/db.php';
-require_once __DIR__ . '/logger.php';
-
 function definitions_fetch_rows(?PDO $pdo = null): array
 {
 

--- a/server/migrate.php
+++ b/server/migrate.php
@@ -1,10 +1,9 @@
 <?php
 
 // Lightweight migration runner. Intended for local development only.
-require_once __DIR__ . '/config/config.php';
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/config/config-root.php';
 require_once __DIR__ . '/lib/db-root.php';
-require_once __DIR__ . '/lib/logger.php';
 
 $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? '';
 $isCli = PHP_SAPI === 'cli';

--- a/server/tests/definitions_move_runner.php
+++ b/server/tests/definitions_move_runner.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 use App\Tests\Support\FakePDO;
 
-require_once __DIR__ . '/../config/config.php';
-require_once __DIR__ . '/../lib/definitions.php';
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/Support/FakePDO.php';
 require_once __DIR__ . '/Support/FakeStatement.php';
 


### PR DESCRIPTION
## Summary
- add a central server/bootstrap.php that loads configuration and shared libraries once per request
- remove side-effecting require statements from library files so they only declare symbols
- update HTTP endpoints, CLI tooling, and tests to pull in the bootstrap before using library helpers

## Testing
- npm run lint:php *(fails: phpstan expects optional exclude paths like public/assets and node_modules to exist)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0bddc0dc8327a01557c028a6ef44