### PR TITLE
fix: start CSRF session before rendering auth forms

### DIFF
--- a/server/index.php
+++ b/server/index.php
@@ -154,4 +154,12 @@ $descMap = [
   '404' => 'Požadovaná stránka nebyla nalezena.'
 ];
 $description = $descMap[$view] ?? 'HAGEMANN konfigurátor - rychlá PWA s PHP SSR.';
+
+$viewsRequiringCsrf = ['login', 'register'];
+if (in_array($view, $viewsRequiringCsrf, true)) {
+    // Ensure the CSRF token is generated before any output so session cookies
+    // can be sent without triggering "headers already sent" warnings.
+    csrf_token();
+}
+
 require __DIR__ . '/views/layout.php';


### PR DESCRIPTION
## Summary
- ensure login and register routes initialize the CSRF token before rendering so sessions can be established before headers are sent
- document intent in index bootstrap to avoid header warnings and allow initial login attempt to succeed

## Testing
- npm run lint *(fails: stylelint not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e667283ed48327ba4cf9a5c91286be