### PR TITLE
Add company address management: DB, API, admin UI and frontend island

### DIFF
--- a/server/controllers/admin/address.php
+++ b/server/controllers/admin/address.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Administration\Repository;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+if (!headers_sent()) {
+    header('Content-Type: application/json; charset=UTF-8');
+}
+
+csrf_require_valid($_POST, 'json');
+
+$user = app_get_current_user();
+$role = $user['role'] ?? 'guest';
+if ($role !== 'superadmin') {
+    http_response_code(403);
+    echo json_encode(['error' => 'Nemáte oprávnění upravovat firemní adresu.']);
+    exit;
+}
+
+$countryCode = strtoupper(trim((string) ($_POST['country_code'] ?? 'CZ')));
+$state = trim((string) ($_POST['state'] ?? ''));
+$city = trim((string) ($_POST['city'] ?? ''));
+$street = trim((string) ($_POST['street'] ?? ''));
+$streetNumber = trim((string) ($_POST['street_number'] ?? ''));
+$postCode = trim((string) ($_POST['post_code'] ?? ''));
+
+if ($countryCode === '' || strlen($countryCode) !== 2) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Kód země musí mít 2 znaky (např. CZ).']);
+    exit;
+}
+
+if (
+    $state === '' ||
+    $city === '' ||
+    $street === '' ||
+    $streetNumber === '' ||
+    $postCode === ''
+) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Vyplňte všechna povinná pole adresy.']);
+    exit;
+}
+
+$repository = new Repository();
+
+try {
+    $addressId = $repository->saveCompanyAddress([
+        'country_code' => $countryCode,
+        'state' => $state,
+        'city' => $city,
+        'street' => $street,
+        'street_number' => $streetNumber,
+        'post_code' => $postCode,
+    ]);
+
+    echo json_encode([
+        'message' => 'Firemní adresa byla uložena.',
+        'address_id' => $addressId,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    log_message('Admin address save failed: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Uložení adresy selhalo.']);
+}

--- a/server/database/migrations/20260316_create_addresses.sql
+++ b/server/database/migrations/20260316_create_addresses.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS addresses (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    country_code CHAR(2) NOT NULL DEFAULT 'CZ',
+    state VARCHAR(120) NOT NULL,
+    city VARCHAR(120) NOT NULL,
+    street VARCHAR(150) NOT NULL,
+    street_number VARCHAR(30) NOT NULL,
+    post_code VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_addresses_country_state_city (country_code, state, city),
+    KEY idx_addresses_post_code (post_code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/index.php
+++ b/server/index.php
@@ -148,6 +148,7 @@ $controllerRoutes = [
     'POST admin/export'                          => __DIR__ . '/controllers/admin/export.php',
     'POST admin/import'                          => __DIR__ . '/controllers/admin/import.php',
     'POST admin/logo'                            => __DIR__ . '/controllers/admin/logo.php',
+    'POST admin/address'                         => __DIR__ . '/controllers/admin/address.php',
 ];
 
 $nonHtmxControllers = [

--- a/server/install.php
+++ b/server/install.php
@@ -312,6 +312,24 @@ SQL;
     SQL;
     $pdo->exec($appSettingsSql);
 
+    $addressesSql = <<<'SQL'
+    CREATE TABLE IF NOT EXISTS addresses (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        country_code CHAR(2) NOT NULL DEFAULT 'CZ',
+        state VARCHAR(120) NOT NULL,
+        city VARCHAR(120) NOT NULL,
+        street VARCHAR(150) NOT NULL,
+        street_number VARCHAR(30) NOT NULL,
+        post_code VARCHAR(20) NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        KEY idx_addresses_country_state_city (country_code, state, city),
+        KEY idx_addresses_post_code (post_code)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    SQL;
+    $pdo->exec($addressesSql);
+
     echo "Database setup complete\n";
 } catch (PDOException $e) {
     fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");

--- a/server/lib/Administration/Repository.php
+++ b/server/lib/Administration/Repository.php
@@ -98,6 +98,113 @@ final class Repository
     }
 
     /**
+     * @param array{country_code: string, state: string, city: string, street: string, street_number: string, post_code: string} $address
+     */
+    public function saveCompanyAddress(array $address): int
+    {
+        $this->pdo->beginTransaction();
+        try {
+            $settings = $this->getMany(['company_address_id']);
+            $existingId = isset($settings['company_address_id']) ? (int) $settings['company_address_id'] : 0;
+
+            if ($existingId > 0) {
+                $update = $this->pdo->prepare(
+                    'UPDATE addresses
+                     SET country_code = :country_code,
+                         state = :state,
+                         city = :city,
+                         street = :street,
+                         street_number = :street_number,
+                         post_code = :post_code
+                     WHERE id = :id'
+                );
+                $update->execute([
+                    ':id' => $existingId,
+                    ':country_code' => $address['country_code'],
+                    ':state' => $address['state'],
+                    ':city' => $address['city'],
+                    ':street' => $address['street'],
+                    ':street_number' => $address['street_number'],
+                    ':post_code' => $address['post_code'],
+                ]);
+
+                if ($update->rowCount() > 0 || $this->addressExists($existingId)) {
+                    $this->set('company_address_id', (string) $existingId);
+                    $this->pdo->commit();
+                    return $existingId;
+                }
+            }
+
+            $insert = $this->pdo->prepare(
+                'INSERT INTO addresses (country_code, state, city, street, street_number, post_code)
+                 VALUES (:country_code, :state, :city, :street, :street_number, :post_code)'
+            );
+            $insert->execute([
+                ':country_code' => $address['country_code'],
+                ':state' => $address['state'],
+                ':city' => $address['city'],
+                ':street' => $address['street'],
+                ':street_number' => $address['street_number'],
+                ':post_code' => $address['post_code'],
+            ]);
+
+            $addressId = (int) $this->pdo->lastInsertId();
+            $this->set('company_address_id', (string) $addressId);
+            $this->pdo->commit();
+
+            return $addressId;
+        } catch (Throwable $e) {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{id: int, country_code: string, state: string, city: string, street: string, street_number: string, post_code: string}|null
+     */
+    public function readCompanyAddress(): ?array
+    {
+        $settings = $this->getMany(['company_address_id']);
+        $addressId = isset($settings['company_address_id']) ? (int) $settings['company_address_id'] : 0;
+        if ($addressId <= 0) {
+            return null;
+        }
+
+        $stmt = $this->pdo->prepare(
+            'SELECT id, country_code, state, city, street, street_number, post_code
+             FROM addresses
+             WHERE id = :id
+             LIMIT 1'
+        );
+        $stmt->execute([':id' => $addressId]);
+
+        /** @var array{id: int|string, country_code: string, state: string, city: string, street: string, street_number: string, post_code: string}|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row['id'],
+            'country_code' => (string) $row['country_code'],
+            'state' => (string) $row['state'],
+            'city' => (string) $row['city'],
+            'street' => (string) $row['street'],
+            'street_number' => (string) $row['street_number'],
+            'post_code' => (string) $row['post_code'],
+        ];
+    }
+
+    private function addressExists(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT id FROM addresses WHERE id = :id LIMIT 1');
+        $stmt->execute([':id' => $id]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
      * Extract width and height from SVG string. Returns [width, height] or defaults if not found.
      * @return array{0: float, 1: float}
      */

--- a/server/views/admin.php
+++ b/server/views/admin.php
@@ -1,5 +1,9 @@
 <?php
 
+require_once __DIR__ . '/../lib/Administration/Repository.php';
+
+use Administration\Repository as AdministrationRepository;
+
 // Normalize base path for view usage.
 $baseCandidate = defined('BASE_PATH') ? (string) BASE_PATH : '';
 $BASE = isset($BASE) && $BASE !== '' ? (string) $BASE : $baseCandidate;
@@ -35,6 +39,9 @@ if ($__editorRole != 'superadmin') {
     echo '</div>';
     return;
 }
+
+$adminRepository = new AdministrationRepository();
+$companyAddress = $adminRepository->readCompanyAddress();
 ?>
 <h1>Administrace</h1>
 <div class="admin-panel">
@@ -173,6 +180,76 @@ if ($__editorRole != 'superadmin') {
         </div>
       </div>
     </div>
+  </section>
+
+  <section class="admin-address" data-island="admin">
+    <h2>Firemní adresa</h2>
+    <p>Nastavte adresu společnosti pro tisk výstupů a další administrativu.</p>
+    <form id="admin-address-form" class="admin-address-form" novalidate>
+      <?= csrf_field(); ?>
+      <label class="admin-field">
+        <span>Kód země</span>
+        <input
+          type="text"
+          name="country_code"
+          maxlength="2"
+          minlength="2"
+          required
+          value="<?= htmlspecialchars((string)($companyAddress['country_code'] ?? 'CZ'), ENT_QUOTES, 'UTF-8') ?>"
+          autocomplete="country">
+      </label>
+      <label class="admin-field">
+        <span>Stát / kraj</span>
+        <input
+          type="text"
+          name="state"
+          required
+          value="<?= htmlspecialchars((string)($companyAddress['state'] ?? ''), ENT_QUOTES, 'UTF-8') ?>"
+          autocomplete="address-level1">
+      </label>
+      <label class="admin-field">
+        <span>Město</span>
+        <input
+          type="text"
+          name="city"
+          required
+          value="<?= htmlspecialchars((string)($companyAddress['city'] ?? ''), ENT_QUOTES, 'UTF-8') ?>"
+          autocomplete="address-level2">
+      </label>
+      <div class="admin-field-row">
+        <label class="admin-field">
+          <span>Ulice</span>
+          <input
+            type="text"
+            name="street"
+            required
+            value="<?= htmlspecialchars((string)($companyAddress['street'] ?? ''), ENT_QUOTES, 'UTF-8') ?>"
+            autocomplete="address-line1">
+        </label>
+        <label class="admin-field">
+          <span>Číslo popisné/orientační</span>
+          <input
+            type="text"
+            name="street_number"
+            required
+            value="<?= htmlspecialchars((string)($companyAddress['street_number'] ?? ''), ENT_QUOTES, 'UTF-8') ?>"
+            autocomplete="address-line2">
+        </label>
+      </div>
+      <label class="admin-field">
+        <span>PSČ</span>
+        <input
+          type="text"
+          name="post_code"
+          required
+          value="<?= htmlspecialchars((string)($companyAddress['post_code'] ?? ''), ENT_QUOTES, 'UTF-8') ?>"
+          autocomplete="postal-code">
+      </label>
+      <div class="admin-modal-actions">
+        <button type="submit" class="admin-action admin-action--primary">Uložit adresu</button>
+      </div>
+      <p id="admin-address-feedback" class="admin-address-feedback hidden" role="status" aria-live="polite"></p>
+    </form>
   </section>
 </div>
 <textarea

--- a/src/islands/administration/admin-address.ts
+++ b/src/islands/administration/admin-address.ts
@@ -1,0 +1,82 @@
+import { getCsrfToken } from '../../utils/api';
+
+type AddressSaveOk = {
+    message: string;
+    address_id: number;
+};
+
+function isAddressSaveOk(payload: unknown): payload is AddressSaveOk {
+    if (typeof payload !== 'object' || payload === null) {
+        return false;
+    }
+
+    const candidate = payload as Record<string, unknown>;
+    return (
+        typeof candidate.message === 'string' &&
+        typeof candidate.address_id === 'number'
+    );
+}
+
+const getAddressError = (payload: unknown): string | null => {
+    if (typeof payload !== 'object' || payload === null) {
+        return null;
+    }
+
+    const candidate = payload as Record<string, unknown>;
+    return typeof candidate.error === 'string' ? candidate.error : null;
+};
+
+const buildAdminUrl = (path: string) => {
+    const base = document.documentElement?.dataset?.base ?? '';
+    return `${base}${path}`;
+};
+
+export const initAdminAddress = (root: HTMLElement) => {
+    const form = root.querySelector<HTMLFormElement>('#admin-address-form');
+    const feedback = root.querySelector<HTMLElement>('#admin-address-feedback');
+    if (!form || !feedback) {
+        return;
+    }
+
+    const showFeedback = (message: string, kind: 'success' | 'error') => {
+        feedback.classList.remove('hidden');
+        feedback.classList.toggle('admin-address-feedback--success', kind === 'success');
+        feedback.classList.toggle('admin-address-feedback--error', kind === 'error');
+        feedback.textContent = message;
+    };
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const formData = new FormData(form);
+        const endpoint = buildAdminUrl('/admin/address');
+
+        try {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                body: formData,
+                credentials: 'include',
+                headers: {
+                    'X-CSRF-Token': getCsrfToken(),
+                },
+            });
+
+            const payload = (await response.json().catch(() => null)) as unknown;
+
+            if (!response.ok) {
+                const message = getAddressError(payload) ?? 'Uložení adresy selhalo.';
+                showFeedback(message, 'error');
+                return;
+            }
+
+            if (isAddressSaveOk(payload)) {
+                showFeedback(payload.message, 'success');
+                return;
+            }
+
+            showFeedback('Adresa byla uložena.', 'success');
+        } catch {
+            showFeedback('Operaci se nepodařilo dokončit.', 'error');
+        }
+    });
+};

--- a/src/islands/administration/index.ts
+++ b/src/islands/administration/index.ts
@@ -1,7 +1,9 @@
 import { initAdminTransfer } from './admin-transfer';
 import { initAdminLogo } from './admin-logo';
+import { initAdminAddress } from './admin-address';
 
 export default (root: HTMLElement) => {
     initAdminTransfer(root);
     initAdminLogo(root);
+    initAdminAddress(root);
 };

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -88,6 +88,61 @@
     margin-top: 0;
 }
 
+.admin-address {
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--bg) 92%, var(--fg) 4%);
+    flex: auto;
+}
+
+.admin-address h2 {
+    margin-top: 0;
+}
+
+.admin-address-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.admin-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.admin-field-row {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.admin-field-row .admin-field {
+    flex: 1 1 0;
+}
+
+.admin-field input {
+    border: 1px solid var(--border);
+    border-radius: 0.4rem;
+    padding: 0.4rem 0.5rem;
+    background: var(--bg);
+    color: inherit;
+}
+
+.admin-address-feedback {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.admin-address-feedback--success {
+    color: var(--success);
+}
+
+.admin-address-feedback--error {
+    color: var(--danger);
+}
+
 .admin-logo-preview {
     --pad: 0.5rem;
     --pad-2x: calc(var(--pad) * 2);


### PR DESCRIPTION
### Motivation
- Provide a place to store and manage the company's address for printed outputs and administrative tasks.
- Expose an authenticated admin API to save the company address.
- Add an admin UI for superadmins to view and update the address and persist it in the application database.

### Description
- Added an `addresses` table migration at `server/database/migrations/20260316_create_addresses.sql` and wired the same DDL into `server/install.php` to create the table during install.
- Implemented repository support in `server/lib/Administration/Repository.php` with `saveCompanyAddress(array): int`, `readCompanyAddress(): ?array` and a private `addressExists(int): bool` helper to persist and read the company address and store its id in `app_settings`.
- Added a new admin controller `server/controllers/admin/address.php` that enforces CSRF and `superadmin` role, validates input, and calls the repository to save the address, returning JSON responses.
- Extended the admin view `server/views/admin.php` to load the current address and render a form, added client-side handling with `src/islands/administration/admin-address.ts` and registered it in `src/islands/administration/index.ts`, and added styling in `src/styles/admin.css`.
- Registered the new route in `server/index.php` as `POST admin/address`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d6a9a60083279d7584b6d6f52e17)