### PR TITLE
fix: avoid CSP-unsafe eval in editor gallery uploads

### DIFF
--- a/server/views/editor/partials/images.php
+++ b/server/views/editor/partials/images.php
@@ -15,8 +15,6 @@ $sanitizedPath = $repository->sanitizeRelative((string) $pathInput);
 [$currentAbsolute, $currentPath] = $repository->resolve($sanitizedPath);
 $beforeSwapHandler = 'htmx:beforeSwap: if (event.detail.xhr && event.detail.xhr.status'
     . ' && event.detail.xhr.status >= 400) { event.detail.shouldSwap = false; }';
-$uploadHxVals = 'js:{ path: document.getElementById("images-root")?.dataset.currentPath'
-    . ' || "" }';
 $currentVersion = (int) @filemtime($currentAbsolute);
 if ($currentVersion <= 0) {
     $currentVersion = time();
@@ -63,10 +61,14 @@ if (isset($_SERVER['HTTP_HX_REQUEST'])) {
         class="upload"
         enctype="multipart/form-data"
         hx-post="<?= htmlspecialchars($BASE) ?>/editor/images/upload"
-        hx-vals="<?= htmlspecialchars($uploadHxVals, ENT_QUOTES, 'UTF-8') ?>"
         hx-target="#image-grid"
         hx-swap="innerHTML">
         <?= csrf_field() ?>
+        <input
+            type="hidden"
+            id="upload-path"
+            name="path"
+            value="<?= htmlspecialchars($currentPath, ENT_QUOTES, 'UTF-8') ?>">
         <label>
             <span>Nahrát obrázky</span>
             <input type="file" name="images[]" accept="image/*" multiple required>
@@ -92,4 +94,3 @@ if (isset($_SERVER['HTTP_HX_REQUEST'])) {
     <!-- Modal container for image preview -->
     <div id="img-modal" class="hidden" aria-hidden="true"></div>
 </div>
-

--- a/src/islands/images.ts
+++ b/src/islands/images.ts
@@ -132,6 +132,7 @@ function mount(el: HTMLElement) {
     const menu = qs<HTMLElement>(el, '#img-context-menu')!;
     const newFolderBtn = qs<HTMLButtonElement>(el, '#new-folder-btn');
     const uploadForm = qs<HTMLFormElement>(el, '#upload-form');
+    const uploadPathInput = qs<HTMLInputElement>(el, '#upload-path');
     const showUploadOverlay = () => {
         uploadOverlay?.show();
     };
@@ -193,7 +194,11 @@ function mount(el: HTMLElement) {
         );
         const currentPath = state?.dataset.currentPath || '';
         el.dataset.currentPath = currentPath;
+        if (uploadPathInput) {
+            uploadPathInput.value = currentPath;
+        }
     };
+    syncCurrentFromGrid();
     document.body.addEventListener('htmx:afterSwap', (evt) => {
         const target = (evt as CustomEvent).detail?.target as
             | HTMLElement


### PR DESCRIPTION
### Motivation
- Uploading images from the editor gallery triggered a CSP `EvalError` because the form used `hx-vals` with a `js:` expression, which causes htmx to `Function(...)`-evaluate a string at runtime and requires `unsafe-eval` in the CSP. 
- Replace the runtime-evaluated `hx-vals` with a normal form field so uploads work under a strict CSP.

### Description
- Removed the `hx-vals="js:{...}"` usage from the upload form in `server/views/editor/partials/images.php` and added a hidden input `#upload-path` (`name="path"`) that holds the current folder path. 
- Updated `src/islands/images.ts` to select `#upload-path` and keep its `.value` synchronized with the displayed folder on mount and after `#image-grid` swaps. 
- Preserves existing behavior: the selected gallery folder is still submitted with the multipart upload, but no runtime JS evaluation is required by htmx.

### Testing
- Ran TypeScript lint (`eslint`) and CSS lint (`stylelint`) which completed successfully in this environment. 
- Ran `npm run lint` which failed late in the PHP lint stage because `phpcs` is not installed here (`sh: 1: phpcs: not found`), so PHP linting could not be completed in CI here. 
- Manual smoke: verified the hidden `#upload-path` is present in the rendered form and the island code updates it after grid swaps (see updated `images.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f56425dc8327986bf51f55c6f00e)