### PR TITLE
fix: hide multi-select child selections from breadcrumbs and stop wizard restart after final multi-select

### DIFF
--- a/server/lib/Configuration/ConfigurationWizard.php
+++ b/server/lib/Configuration/ConfigurationWizard.php
@@ -326,8 +326,7 @@ final class ConfigurationWizard
         if ($nextRoot !== null) {
             $newCurrent = (int) $nextRoot['id'];
         } else {
-            $lastSelectedId = end($normalisedIds);
-            $newCurrent = $lastSelectedId !== false ? (int) $lastSelectedId : null;
+            $newCurrent = (int) $normalisedIds[count($normalisedIds) - 1];
         }
         $this->repository->updateCurrentComponent($this->configurationId, $newCurrent);
         $this->currentComponentId = $newCurrent;

--- a/server/lib/Configuration/ConfigurationWizard.php
+++ b/server/lib/Configuration/ConfigurationWizard.php
@@ -161,6 +161,11 @@ final class ConfigurationWizard
         $pathPrefix = [];
 
         foreach ($selectedPath as $selection) {
+            if ($this->selectionBelongsToMultiSelectStep($selection)) {
+                $pathPrefix[] = $selection;
+                continue;
+            }
+
             $availableOptions = $this->resolveAvailableOptionsForSelectionParent($selection, $pathPrefix);
             if (count($availableOptions) !== 1) {
                 $breadcrumbPath[] = $selection;
@@ -316,8 +321,14 @@ final class ConfigurationWizard
         }
 
         $this->selectedPath = null;
-        $nextRoot = $this->findNextEligibleRootAfter($this->currentComponentId, $this->getSelectedPath());
-        $newCurrent = $nextRoot !== null ? (int) $nextRoot['id'] : null;
+        $updatedPath = $this->getSelectedPath();
+        $nextRoot = $this->findNextEligibleRootAfter($this->currentComponentId, $updatedPath);
+        if ($nextRoot !== null) {
+            $newCurrent = (int) $nextRoot['id'];
+        } else {
+            $lastSelectedId = end($normalisedIds);
+            $newCurrent = $lastSelectedId !== false ? (int) $lastSelectedId : null;
+        }
         $this->repository->updateCurrentComponent($this->configurationId, $newCurrent);
         $this->currentComponentId = $newCurrent;
     }
@@ -599,5 +610,25 @@ final class ConfigurationWizard
         }
 
         return $available;
+    }
+
+    /**
+     * @param array<string, mixed> $selection
+     */
+    private function selectionBelongsToMultiSelectStep(array $selection): bool
+    {
+        $parentComponentId = isset($selection['parent_component_id'])
+            ? (int) $selection['parent_component_id']
+            : 0;
+        if ($parentComponentId <= 0) {
+            return false;
+        }
+
+        $parentComponent = $this->components->find($parentComponentId);
+        if ($parentComponent === null) {
+            return false;
+        }
+
+        return !empty($parentComponent['allow_multi_select']);
     }
 }


### PR DESCRIPTION
### Motivation
- Child options chosen inside a multi-select step were rendered as separate breadcrumb items instead of only showing the parent step, which polluted the breadcrumb trail.
- After finishing the last step when that step is a multi-select, the wizard reset to the beginning because `current_component_id` became `NULL`, causing an endless restart loop instead of landing on a terminal state.

### Description
- Update `getBreadcrumbPath()` to skip selections whose parent component has `allow_multi_select` by adding a helper `selectionBelongsToMultiSelectStep()` to detect multi-select parent steps, so only the parent step appears in breadcrumbs (`server/lib/Configuration/ConfigurationWizard.php`).
- Change `selectMultipleComponents()` progression logic to compute the updated selected path and, when no next eligible root is available, set the new current component to the last selected option instead of `NULL`, preventing the wizard from restarting (`server/lib/Configuration/ConfigurationWizard.php`).
- Preserve the original progression when a next eligible root exists and clear the selected path cache after inserts.

### Testing
- Ran `php -l server/lib/Configuration/ConfigurationWizard.php` and it reported no syntax errors.
- Ran `npm run lint`; TypeScript and CSS lint steps completed, but the PHP lint stage failed in this environment because the `phpcs` binary is not installed, so the full lint pipeline did not finish successfully.
- No other automated tests were available in the execution environment to exercise the end-to-end wizard flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9c72b3acc8327a5e346251b368827)