### PR TITLE
fix: keep editor navigation sticky

### DIFF
--- a/src/islands/shared/select.css
+++ b/src/islands/shared/select.css
@@ -29,7 +29,6 @@
     border: 0.15rem solid currentcolor;
     border-left: 0;
     border-top: 0;
-
     transform: rotate(45deg);
     float: right;
     margin-top: 0.125rem;

--- a/src/styles/checkbox.css
+++ b/src/styles/checkbox.css
@@ -6,7 +6,6 @@
 .checkbox-wrapper-46 .cbx {
     margin: auto;
     user-select: none;
-    user-select: none;
     cursor: pointer;
 }
 

--- a/src/styles/editor/components.css
+++ b/src/styles/editor/components.css
@@ -349,7 +349,9 @@
 
 .component-field .component-checkbox {
     min-height: calc(1.5em + 0.8rem + 2px);
+
     /* border: 1px solid var(--border); */
+
     /* border-radius: 0.35rem; */
     padding: 0.4rem 0;
     background: transparent;

--- a/src/styles/konfigurator/component-options.css
+++ b/src/styles/konfigurator/component-options.css
@@ -43,7 +43,7 @@
 }
 
 .component-card:hover {
-    box-shadow: 0 12px 18px -4px rgba(0 0 0 / 30%);
+    box-shadow: 0 12px 18px -4px rgb(0 0 0 / 30%);
     transform: translateY(-6px) scale(1.03);
 }
 

--- a/src/styles/subnav.css
+++ b/src/styles/subnav.css
@@ -67,3 +67,9 @@
 .sub-nav-link.is-active:focus-visible {
     color: var(--primary-contrast);
 }
+
+#editor-nav-menu {
+    position: sticky;
+    top: 0.5rem;
+    z-index: 20;
+}


### PR DESCRIPTION
### Motivation
- Make the editor sub-navigation remain visible while scrolling long editor lists so users can quickly switch sections without scrolling back to the top.

### Description
- Add a sticky positioning rule for `#editor-nav-menu` in `src/styles/subnav.css` and include minor CSS lint autofixes applied to a few style files (`src/islands/shared/select.css`, `src/styles/checkbox.css`, `src/styles/editor/components.css`, `src/styles/konfigurator/component-options.css`).

### Testing
- Ran `composer --working-dir=server install` to provide PHP dev dependencies required by the test harness and it completed successfully.
- Ran `npm run lint` and it completed with no blocking errors after the style fixes.
- Ran `npm test -- --runInBand` and all Jest suites passed.
- Ran `npm run build` and the production build completed successfully (assets emitted and service worker written).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475886b3dc83278a581542acc81341)