### PR TITLE
feat: add copy/paste for component editor rows

### DIFF
--- a/server/views/editor/partials/components-chunk.php
+++ b/server/views/editor/partials/components-chunk.php
@@ -357,6 +357,24 @@ foreach ($items as $node) {
           <button
             type="button"
             class="component-action"
+            data-action="copy"
+            aria-label="Kopírovat vlastnosti"
+            title="Kopírovat vlastnosti"
+          >
+            Kopírovat
+          </button>
+          <button
+            type="button"
+            class="component-action hidden"
+            data-action="paste"
+            aria-label="Vložit zkopírované vlastnosti"
+            title="Vložit zkopírované vlastnosti"
+          >
+            Vložit
+          </button>
+          <button
+            type="button"
+            class="component-action"
             data-action="clone"
           >
             <svg

--- a/src/islands/components/actions.ts
+++ b/src/islands/components/actions.ts
@@ -1,9 +1,274 @@
 import type { ComponentApiClient } from './types';
 import { parsePriceHistoryDataset } from './form';
 import { ComponentModalManager } from './modal';
-import { ComponentModalOptions } from './types';
+import { ComponentModalOptions, ComponentProperty } from './types';
 import { escapeHtml, parseImagesDataset } from './utils';
 import { listSelectors } from './constants';
+
+type CopyKey = 'description' | 'images' | 'properties' | 'color' | 'price';
+
+type CopyOption = {
+    key: CopyKey;
+    label: string;
+    summary: string;
+};
+
+type ComponentCopyPayload = {
+    copiedAt: number;
+    sourceTitle: string;
+    values: Partial<Pick<ComponentModalOptions, 'description' | 'images' | 'image' | 'properties' | 'color' | 'mediaType' | 'priceAmount' | 'priceCurrency'>>;
+};
+
+const CLIPBOARD_KEY = 'editor.componentCopyClipboard.v1';
+
+const parseProperties = (raw: string | undefined): ComponentProperty[] => {
+    try {
+        const parsed = JSON.parse(raw ?? '[]') as unknown;
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(
+            (entry): entry is ComponentProperty =>
+                entry !== null && typeof entry === 'object'
+        );
+    } catch {
+        return [];
+    }
+};
+
+const readItemOptions = (item: HTMLElement): ComponentModalOptions => {
+    const parentId = item.dataset.parent ?? '';
+    const positionRaw = item.dataset.position;
+    const parsedPosition =
+        positionRaw !== undefined ? Number.parseInt(positionRaw, 10) : NaN;
+    const priceAmount = item.dataset.priceAmount ?? '';
+    const priceCurrency = item.dataset.priceCurrency ?? 'CZK';
+
+    return {
+        mode: 'edit',
+        componentId: item.dataset.id ?? '',
+        definitionId: item.dataset.definitionId ?? '',
+        alternateTitle: item.dataset.alternateTitle ?? '',
+        description: item.dataset.description ?? '',
+        image: item.dataset.image ?? '',
+        images: parseImagesDataset(item.dataset.images, item.dataset.image),
+        color: item.dataset.color ?? '',
+        mediaType:
+            (item.dataset.mediaType as 'image' | 'color' | undefined) ??
+            undefined,
+        parentId,
+        position: Number.isNaN(parsedPosition) ? undefined : parsedPosition,
+        displayName: item.dataset.title ?? '',
+        priceAmount,
+        priceCurrency,
+        priceHistory: parsePriceHistoryDataset(item.dataset.priceHistory),
+        dependencyTree: item.dataset.dependencyTree ?? '',
+        properties: parseProperties(item.dataset.properties),
+        allowMultiSelect: item.dataset.allowMultiSelect === '1',
+    };
+};
+
+const getCopyOptions = (options: ComponentModalOptions): CopyOption[] => {
+    const copyOptions: CopyOption[] = [];
+    const images = options.images ?? [];
+    const properties = options.properties ?? [];
+
+    if ((options.description ?? '').trim() !== '') {
+        copyOptions.push({
+            key: 'description',
+            label: 'Popis',
+            summary: options.description ?? '',
+        });
+    }
+
+    if (images.length > 0) {
+        copyOptions.push({
+            key: 'images',
+            label: 'Sada obrázků',
+            summary: `${images.length} obr.`,
+        });
+    }
+
+    if (properties.length > 0) {
+        copyOptions.push({
+            key: 'properties',
+            label: 'Vlastnosti',
+            summary: `${properties.length} položek`,
+        });
+    }
+
+    if ((options.color ?? '').trim() !== '') {
+        copyOptions.push({
+            key: 'color',
+            label: 'Barva',
+            summary: options.color ?? '',
+        });
+    }
+
+    if ((options.priceAmount ?? '').trim() !== '') {
+        copyOptions.push({
+            key: 'price',
+            label: 'Cena',
+            summary: `${options.priceAmount} ${options.priceCurrency ?? 'CZK'}`,
+        });
+    }
+
+    return copyOptions;
+};
+
+const readClipboard = (): ComponentCopyPayload | null => {
+    try {
+        const raw = window.localStorage.getItem(CLIPBOARD_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as ComponentCopyPayload;
+        if (!parsed || typeof parsed !== 'object' || !parsed.values) {
+            return null;
+        }
+        return parsed;
+    } catch {
+        return null;
+    }
+};
+
+const writeClipboard = (payload: ComponentCopyPayload) => {
+    window.localStorage.setItem(CLIPBOARD_KEY, JSON.stringify(payload));
+    window.dispatchEvent(new CustomEvent('component-copy:changed'));
+};
+
+const labelsForPayload = (payload: ComponentCopyPayload | null): string[] => {
+    if (!payload) return [];
+    const labels: string[] = [];
+    if (payload.values.description !== undefined) labels.push('Popis');
+    if (payload.values.images !== undefined) labels.push('Obrázky');
+    if (payload.values.properties !== undefined) labels.push('Vlastnosti');
+    if (payload.values.color !== undefined) labels.push('Barva');
+    if (payload.values.priceAmount !== undefined) labels.push('Cena');
+    return labels;
+};
+
+const updatePasteButtons = (root: HTMLElement) => {
+    const hasClipboard = readClipboard() !== null;
+    root.querySelectorAll<HTMLButtonElement>('[data-action="paste"]').forEach(
+        (button) => {
+            button.classList.toggle('hidden', !hasClipboard);
+            button.setAttribute('aria-hidden', hasClipboard ? 'false' : 'true');
+        }
+    );
+};
+
+const ensureIndicator = () => {
+    let indicator = document.querySelector<HTMLElement>(
+        '[data-component-copy-indicator]'
+    );
+
+    if (!indicator) {
+        indicator = document.createElement('div');
+        indicator.className = 'component-copy-indicator hidden';
+        indicator.dataset.componentCopyIndicator = 'true';
+        document.body.appendChild(indicator);
+    }
+
+    const payload = readClipboard();
+    const labels = labelsForPayload(payload);
+    indicator.classList.toggle('hidden', labels.length === 0);
+    indicator.innerHTML = payload
+        ? `<strong>V paměti kopie</strong><span>${escapeHtml(
+              labels.join(', ')
+          )}</span><small>Zdroj: ${escapeHtml(payload.sourceTitle)}</small>`
+        : '';
+};
+
+const setupClipboardUi = (root: HTMLElement) => {
+    updatePasteButtons(root);
+    ensureIndicator();
+    window.addEventListener('component-copy:changed', () => {
+        updatePasteButtons(root);
+        ensureIndicator();
+    });
+    window.addEventListener('storage', (event) => {
+        if (event.key === CLIPBOARD_KEY) {
+            updatePasteButtons(root);
+            ensureIndicator();
+        }
+    });
+};
+
+const openCopyModal = (
+    item: HTMLElement,
+    title: string,
+    modal: ComponentModalManager
+) => {
+    const options = readItemOptions(item);
+    const copyOptions = getCopyOptions(options);
+    const container = document.createElement('div');
+    container.className = 'component-modal-body';
+
+    if (copyOptions.length === 0) {
+        container.innerHTML = `<p>Komponenta <strong>${escapeHtml(
+            title
+        )}</strong> nemá žádné vyplněné údaje vhodné ke kopírování.</p>`;
+        modal.open('Kopírovat vlastnosti', container);
+        return;
+    }
+
+    container.innerHTML = `
+        <p>Vyberte údaje, které chcete uložit do lokální paměti pro vložení do jiné komponenty.</p>
+        <fieldset class="component-copy-options">
+          <legend class="sr-only">Údaje ke kopírování</legend>
+          ${copyOptions
+              .map(
+                  (option) => `
+                    <label class="component-checkbox component-copy-option">
+                      <input type="checkbox" value="${option.key}" checked>
+                      <span><strong>${escapeHtml(option.label)}</strong><small>${escapeHtml(
+                        option.summary
+                    )}</small></span>
+                    </label>`
+              )
+              .join('')}
+        </fieldset>
+        <div class="components-modal-actions">
+          <button type="button" class="component-action" data-modal-close>Storno</button>
+          <button type="button" class="component-primary" data-copy-confirm>Kopírovat</button>
+        </div>`;
+
+    modal.open('Kopírovat vlastnosti', container);
+    container
+        .querySelector<HTMLButtonElement>('[data-copy-confirm]')
+        ?.addEventListener('click', () => {
+            const selected = Array.from(
+                container.querySelectorAll<HTMLInputElement>(
+                    '.component-copy-option input:checked'
+                )
+            ).map((input) => input.value as CopyKey);
+            const values: ComponentCopyPayload['values'] = {};
+
+            if (selected.includes('description')) {
+                values.description = options.description ?? '';
+            }
+            if (selected.includes('images')) {
+                values.images = options.images ?? [];
+                values.image = options.image ?? '';
+                values.mediaType = 'image';
+            }
+            if (selected.includes('properties')) {
+                values.properties = options.properties ?? [];
+            }
+            if (selected.includes('color')) {
+                values.color = options.color ?? '';
+                values.mediaType = 'color';
+            }
+            if (selected.includes('price')) {
+                values.priceAmount = options.priceAmount ?? '';
+                values.priceCurrency = options.priceCurrency ?? 'CZK';
+            }
+
+            writeClipboard({
+                copiedAt: Date.now(),
+                sourceTitle: title,
+                values,
+            });
+            modal.close();
+        });
+};
 
 export const setupNodeActions = (
     root: HTMLElement,
@@ -11,6 +276,8 @@ export const setupNodeActions = (
     modal: ComponentModalManager,
     openComponentModal: (options?: ComponentModalOptions) => void
 ) => {
+    setupClipboardUi(root);
+
     root.addEventListener('click', (event) => {
         const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
             listSelectors.action
@@ -39,63 +306,17 @@ export const setupNodeActions = (
                 childCount,
             });
         } else if (action === 'edit') {
-            const parentId = item.dataset.parent ?? '';
-            const positionRaw = item.dataset.position;
-            const parsedPosition =
-                positionRaw !== undefined
-                    ? Number.parseInt(positionRaw, 10)
-                    : NaN;
-            const priceAmount = item.dataset.priceAmount ?? '';
-            const priceCurrency = item.dataset.priceCurrency ?? 'CZK';
-            const priceHistory = parsePriceHistoryDataset(
-                item.dataset.priceHistory
-            );
-            const images = parseImagesDataset(
-                item.dataset.images,
-                item.dataset.image
-            );
-            const propertiesRaw = item.dataset.properties ?? '[]';
-            let properties = undefined;
-            try {
-                const parsed = JSON.parse(propertiesRaw) as unknown;
-                if (Array.isArray(parsed)) {
-                    properties = parsed.filter(
-                        (
-                            entry
-                        ): entry is {
-                            name?: string;
-                            value?: string;
-                            unit?: string;
-                        } => entry !== null && typeof entry === 'object'
-                    );
-                }
-            } catch {
-                properties = undefined;
+            openComponentModal(readItemOptions(item));
+        } else if (action === 'copy') {
+            openCopyModal(item, title, modal);
+        } else if (action === 'paste') {
+            const payload = readClipboard();
+            if (payload) {
+                openComponentModal({
+                    ...readItemOptions(item),
+                    ...payload.values,
+                });
             }
-            openComponentModal({
-                mode: 'edit',
-                componentId: id,
-                definitionId: item.dataset.definitionId ?? '',
-                alternateTitle: item.dataset.alternateTitle ?? '',
-                description: item.dataset.description ?? '',
-                image: item.dataset.image ?? '',
-                images,
-                color: item.dataset.color ?? '',
-                mediaType:
-                    (item.dataset.mediaType as 'image' | 'color' | undefined) ??
-                    undefined,
-                parentId,
-                position: Number.isNaN(parsedPosition)
-                    ? undefined
-                    : parsedPosition,
-                displayName: title ?? '',
-                priceAmount,
-                priceCurrency,
-                priceHistory,
-                dependencyTree: item.dataset.dependencyTree ?? '',
-                properties,
-                allowMultiSelect: item.dataset.allowMultiSelect === '1',
-            });
         } else if (action === 'clone') {
             api.cloneComponent(id);
         } else if (action === 'delete') {

--- a/src/styles/editor/components.css
+++ b/src/styles/editor/components.css
@@ -349,7 +349,9 @@
 
 .component-field .component-checkbox {
     min-height: calc(1.5em + 0.8rem + 2px);
+
     /* border: 1px solid var(--border); */
+
     /* border-radius: 0.35rem; */
     padding: 0.4rem 0;
     background: transparent;
@@ -918,4 +920,69 @@
 .component-properties-preview {
     margin: 0;
     padding-left: 1rem;
+}
+
+.component-copy-options {
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    display: grid;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.75rem;
+}
+
+.component-copy-option {
+    align-items: flex-start;
+    border: 1px solid var(--border);
+    border-radius: 0.4rem;
+    display: flex;
+    gap: 0.6rem;
+    padding: 0.55rem;
+}
+
+.component-copy-option span {
+    display: grid;
+    gap: 0.15rem;
+}
+
+.component-copy-option small {
+    color: var(--fg-muted, #6b7280);
+    font-size: 0.75rem;
+}
+
+.component-copy-indicator {
+    background: var(--bg);
+    border: 1px solid var(--primary);
+    border-radius: 0.75rem;
+    box-shadow: 0 12px 32px rgb(0 0 0 / 20%);
+    color: var(--fg);
+    display: grid;
+    gap: 0.15rem;
+    max-width: min(18rem, calc(100vw - 2rem));
+    padding: 0.75rem 0.9rem;
+    position: fixed;
+    right: 1rem;
+    top: 1rem;
+    z-index: 1500;
+}
+
+.component-copy-indicator::before {
+    background: var(--primary);
+    border-radius: 999px;
+    content: '';
+    height: 0.55rem;
+    position: absolute;
+    right: 0.6rem;
+    top: 0.6rem;
+    width: 0.55rem;
+}
+
+.component-copy-indicator span,
+.component-copy-indicator small {
+    color: var(--fg-muted, #6b7280);
+    font-size: 0.78rem;
+}
+
+.component-copy-indicator.hidden {
+    display: none;
 }


### PR DESCRIPTION
### Motivation
- Provide a quick way to copy selected properties from one editor component and paste them into another to speed editing workflows.
- Keep UI minimal and context-aware by only presenting copy options that exist on the source component and only showing paste controls when clipboard content is present.
- Use client-side storage so copying works across modals/pages without server changes and without adding runtime deps.

### Description
- Add `Copy` and `Paste` buttons to each component row in the editor UI by updating `server/views/editor/partials/components-chunk.php` so paste is hidden unless clipboard data exists.
- Implement a local clipboard stored in `localStorage` (`editor.componentCopyClipboard.v1`) and clipboard UI logic in `src/islands/components/actions.ts`, including: conditional option detection, a checkbox modal to select which fields to copy, writing/reading the payload, emitting a `component-copy:changed` event, and exposing paste behavior into the edit modal.
- Add a lightweight floating indicator that appears top-right showing which property groups are currently copied and a small source label, and add scoped styles for the modal options and indicator in `src/styles/editor/components.css`.
- Preserve existing behavior for edit/clone/delete and ensure the new UI is progressive-enhancement only (server-rendered PHP still provides full content and the JS enhances actions).

### Testing
- Ran `npm run lint` (TS + CSS + PHP linters) which completed successfully with no lint errors.
- Ran the production build via the repo `build` script (`npm run build`) and the client assets were produced successfully.
- Attempted an automated UI screenshot with Playwright, but browser download/install was blocked in the environment (Playwright browser download returned 403), so the visual smoke-check could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4758025ec08327b5f49aa8cd5ae90d)