### PR TITLE
style: soften editor subnav backdrop

### DIFF
--- a/src/styles/subnav.css
+++ b/src/styles/subnav.css
@@ -72,5 +72,41 @@
     position: sticky;
     top: 4rem;
     z-index: 20;
-    background: rgb(127 127 127);
+    margin: 0 -1rem 1rem;
+    padding: 2rem 1rem;
+    background: rgb(255 255 255 / 72%);
+    border-color: rgb(255 255 255 / 52%);
+    border-radius: 0;
+    border-width: 0 0 1px;
+    box-shadow: 0 1.25rem 2rem -2rem rgb(15 23 42 / 55%);
+    backdrop-filter: blur(18px);
+}
+
+#editor-nav-menu::after {
+    position: absolute;
+    right: 0;
+    bottom: -1.5rem;
+    left: 0;
+    height: 1.5rem;
+    pointer-events: none;
+    content: '';
+    background: linear-gradient(
+        to bottom,
+        rgb(255 255 255 / 34%),
+        rgb(255 255 255 / 0%)
+    );
+}
+
+[data-theme='dark'] #editor-nav-menu {
+    background: rgb(17 24 39 / 72%);
+    border-color: rgb(255 255 255 / 12%);
+    box-shadow: 0 1.25rem 2rem -2rem rgb(0 0 0 / 85%);
+}
+
+[data-theme='dark'] #editor-nav-menu::after {
+    background: linear-gradient(
+        to bottom,
+        rgb(17 24 39 / 42%),
+        rgb(17 24 39 / 0%)
+    );
 }


### PR DESCRIPTION
### Motivation
- Improve the editor sub-navigation visual hierarchy by adding a translucent blurred backdrop and increased vertical spacing so the subnav reads as a distinct, soft app-shell layer.
- Give the subnav a gentle bottom fade to avoid a harsh edge when it sits above content and provide matching light/dark theme treatments.
- Keep changes purely presentational with no new runtime dependencies and minimal asset impact to preserve the project's performance budgets.

### Description
- Updated `src/styles/subnav.css` to make `#editor-nav-menu` sticky with `margin: 0 -1rem 1rem`, `padding: 2rem 1rem` (2rem vertical), a translucent background, and `backdrop-filter: blur(18px)` for the blurred backdrop.
- Added a `#editor-nav-menu::after` pseudo-element that renders a soft bottom fade edge via a linear-gradient and is pointer-events-safe.
- Added dark-theme overrides under `[data-theme='dark']` for both the backdrop and the pseudo-element so the effect matches the dark UI.
- No server, PHP, or JS behavior was changed; this is a CSS-only visual refinement in the existing subnav stylesheet.

### Testing
- Ran the style linter via `npm run lint` (ESLint/Stylelint/PHPCS hooks) and it completed with no lint errors.
- Ran unit/integration tests with `npm test -- --runInBand` (Jest) and all test suites passed.
- Built production assets with `npm run build` and verified the subnav CSS asset (`subnav-*.css`) remains small (1.78 kB / 0.73 kB gzip).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475f0415908327978ee22a51a221f5)